### PR TITLE
feat: add transaction builder

### DIFF
--- a/.changeset/silent-peaches-pay.md
+++ b/.changeset/silent-peaches-pay.md
@@ -1,0 +1,5 @@
+---
+"gill": minor
+---
+
+Add Transaction Builder

--- a/packages/gill/src/__tests__/create-transaction-builder.test.ts
+++ b/packages/gill/src/__tests__/create-transaction-builder.test.ts
@@ -1,0 +1,371 @@
+import assert from "node:assert";
+
+import {
+  generateKeyPairSigner,
+  lamports,
+  type KeyPairSigner,
+  type Instruction,
+  type MicroLamports,
+} from "@solana/kit";
+import {
+  getTransferSolInstruction,
+  getAddMemoInstruction
+} from "../programs";
+import { createTransactionBuilder } from "../core/create-transaction-builder";
+import { createSolanaClient } from "../core/create-solana-client";
+import type { SolanaClient } from "../types/rpc";
+
+const DEFAULTS = {
+  computeLimit: 200_000,
+  priorityFee: 1n,
+}
+
+describe("createTransactionBuilder (functional)", () => {
+  let feePayer: KeyPairSigner;
+  let recipient: KeyPairSigner;
+  let mockClient: SolanaClient;
+  let transferInstruction: Instruction;
+  let memoInstruction: Instruction;
+
+  beforeAll(async () => {
+    feePayer = await generateKeyPairSigner();
+    recipient = await generateKeyPairSigner();
+
+    mockClient = createSolanaClient({
+      urlOrMoniker: "localnet",
+    });
+
+    transferInstruction = getTransferSolInstruction({
+      source: feePayer,
+      destination: recipient.address,
+      amount: lamports(1_000_000n),
+    });
+
+    memoInstruction = getAddMemoInstruction({
+      memo: "Hello, world!",
+    });
+  });
+
+  describe("factory function", () => {
+    test("creates a builder with default configuration", () => {
+      const builder = createTransactionBuilder({
+        client: mockClient,
+        feePayer,
+      });
+
+      const config = builder.getConfig();
+      assert.equal(config.feePayer, feePayer.address);
+      assert.equal(config.computeLimit, DEFAULTS.computeLimit);
+      assert.equal(config.priorityFee, DEFAULTS.priorityFee);
+      assert.equal(config.instructions.length, 0);
+      assert.equal(config.isPrepared, false);
+      assert.equal(config.version, 'legacy');
+    });
+
+    test("creates a builder with custom configuration", () => {
+      const computeLimit = 200_000;
+      const priorityFee = 5000n as MicroLamports;
+      const builder = createTransactionBuilder({
+        client: mockClient,
+        feePayer,
+        computeLimit,
+        priorityFee,
+        version: 0,
+      });
+
+      const config = builder.getConfig();
+      assert.equal(config.computeLimit, computeLimit);
+      assert.equal(config.priorityFee, priorityFee);
+      assert.equal(config.version, 0);
+    });
+  });
+
+  describe("add instructions", () => {
+    test("adds a single instruction", () => {
+      const builder = createTransactionBuilder({
+        client: mockClient,
+        feePayer,
+      });
+
+      builder.add(transferInstruction);
+      assert.equal(builder.getConfig().instructions.length, 1);
+    });
+
+    test("adds multiple instructions with addMany", () => {
+      const builder = createTransactionBuilder({
+        client: mockClient,
+        feePayer,
+      });
+
+      const instructions = [transferInstruction, memoInstruction];
+      builder.addMany(instructions);
+      assert.equal(builder.getConfig().instructions.length, 2);
+      assert.equal(builder.getConfig().instructions[0], transferInstruction);
+      assert.equal(builder.getConfig().instructions[1], memoInstruction);
+    });
+
+    test("supports method chaining", () => {
+      const computeLimit = 200_000;
+      const priorityFee = 1000n as MicroLamports;
+      const beforeAddInstructions = createTransactionBuilder({
+        client: mockClient,
+        feePayer,
+      });
+
+      assert.equal(beforeAddInstructions.getConfig().instructions.length, 0);
+
+      const beforeSetComputeAndPriorityFee = beforeAddInstructions
+        .add(transferInstruction)
+        .add(memoInstruction)
+
+      assert.equal(beforeSetComputeAndPriorityFee.getConfig().instructions.length, 2);
+      assert.equal(beforeSetComputeAndPriorityFee.getConfig().instructions[0], transferInstruction);
+      assert.equal(beforeSetComputeAndPriorityFee.getConfig().instructions[1], memoInstruction);
+      assert.equal(beforeSetComputeAndPriorityFee.getConfig().computeLimit, DEFAULTS.computeLimit);
+      assert.equal(beforeSetComputeAndPriorityFee.getConfig().priorityFee, DEFAULTS.priorityFee);
+
+      const afterSetComputeAndPriorityFee = beforeSetComputeAndPriorityFee
+        .setComputeLimit(computeLimit)
+        .setPriorityFee(priorityFee);
+
+      assert.equal(afterSetComputeAndPriorityFee.getConfig().instructions.length, 2);
+      assert.equal(afterSetComputeAndPriorityFee.getConfig().instructions[0], transferInstruction);
+      assert.equal(afterSetComputeAndPriorityFee.getConfig().instructions[1], memoInstruction);
+      assert.equal(afterSetComputeAndPriorityFee.getConfig().computeLimit, computeLimit);
+      assert.equal(afterSetComputeAndPriorityFee.getConfig().priorityFee, priorityFee);
+    });
+
+    test("state isolation prevents interference between builders", () => {
+      // Since we can't easily mock closure state, test that the API exists
+      // and that state is properly isolated between instances
+      const builder1 = createTransactionBuilder({
+        client: mockClient,
+        feePayer,
+      });
+      
+      const builder2 = createTransactionBuilder({
+        client: mockClient,
+        feePayer,
+      });
+
+      builder1.add(transferInstruction);
+      builder2.add(memoInstruction);
+
+      assert.equal(builder1.getConfig().instructions.length, 1);
+      assert.equal(builder2.getConfig().instructions.length, 1);
+      assert.equal(builder1.getConfig().instructions[0], transferInstruction);
+      assert.equal(builder2.getConfig().instructions[0], memoInstruction);
+    });
+  });
+
+  describe("setters", () => {
+    test("sets compute limit", () => {
+      const builder = createTransactionBuilder({
+        client: mockClient,
+        feePayer,
+      });
+
+      builder.setComputeLimit(300_000);
+      assert.equal(builder.getConfig().computeLimit, 300_000);
+    });
+
+    test("sets priority fee with different types", () => {
+      const builder = createTransactionBuilder({
+        client: mockClient,
+        feePayer,
+      });
+
+      // Test with number
+      builder.setPriorityFee(1000);
+      assert.equal(builder.getConfig().priorityFee, 1000n);
+
+      // Test with bigint
+      builder.setPriorityFee(2000n);
+      assert.equal(builder.getConfig().priorityFee, 2000n);
+
+      // Test with MicroLamports
+      builder.setPriorityFee(3000n as MicroLamports);
+      assert.equal(builder.getConfig().priorityFee, 3000n);
+    });
+
+    test("validates input parameters correctly", () => {
+      const builder = createTransactionBuilder({
+        client: mockClient,
+        feePayer,
+      });
+
+      // Test that setters work correctly with valid inputs
+      builder.setComputeLimit(300_000);
+      assert.equal(builder.getConfig().computeLimit, 300_000);
+      
+      builder.setPriorityFee(2000n);
+      assert.equal(builder.getConfig().priorityFee, 2000n);
+    });
+
+    test("throws error when setting compute limit to negative", () => {
+      const builder = createTransactionBuilder({
+        client: mockClient,
+        feePayer,
+      });
+
+      assert.throws(
+        () => builder.setComputeLimit(-1),
+        /Compute limit cannot be negative/
+      );
+    });
+
+    test("throws error when setting priority fee to negative", () => {
+      const builder = createTransactionBuilder({
+        client: mockClient,
+        feePayer,
+      });
+
+      assert.throws(
+        () => builder.setPriorityFee(-1n),
+        /Priority fee cannot be negative/
+      );
+    });
+  });
+
+  describe("prepare", () => {
+    test("throws error when no instructions added", async () => {
+      const builder = createTransactionBuilder({
+        client: mockClient,
+        feePayer,
+      });
+
+      await assert.rejects(
+        async () => await builder.prepare(),
+        /Cannot prepare transaction with no instructions/
+      );
+    });
+
+    test("has prepare method available", () => {
+      const builder = createTransactionBuilder({
+        client: mockClient,
+        feePayer,
+      });
+
+      builder.add(transferInstruction);
+      
+      // Test that prepare method exists and is callable
+      assert.equal(typeof builder.prepare, 'function');
+      
+      // Note: Full prepare testing requires network access
+      // This test confirms the API structure is correct
+    });
+
+  });
+
+  describe("sign and send", () => {
+    test("throws error when signing without prepare", async () => {
+      const builder = createTransactionBuilder({
+        client: mockClient,
+        feePayer,
+      });
+
+      await assert.rejects(
+        async () => await builder.sign(),
+        /Transaction must be prepared before signing/
+      );
+    });
+
+    test("throws error when sending without prepare", async () => {
+      const builder = createTransactionBuilder({
+        client: mockClient,
+        feePayer,
+      });
+
+      await assert.rejects(
+        async () => await builder.sendAndConfirm(),
+        /Transaction must be prepared before sending/
+      );
+    });
+  });
+
+  describe("reset", () => {
+    test("resets the builder state", () => {
+      const builder = createTransactionBuilder({
+        client: mockClient,
+        feePayer,
+      });
+
+      builder.add(transferInstruction);
+      builder.add(transferInstruction);
+      assert.equal(builder.getConfig().instructions.length, 2);
+
+      builder.reset();
+      assert.equal(builder.getConfig().instructions.length, 0);
+      assert.equal(builder.getConfig().isPrepared, false);
+      assert.equal(builder.getTransactionMessage(), null);
+    });
+
+    test("allows reuse after reset", () => {
+      const builder = createTransactionBuilder({
+        client: mockClient,
+        feePayer,
+      });
+
+      builder.add(transferInstruction);
+      builder.reset();
+      builder.add(transferInstruction);
+      builder.add(memoInstruction);
+
+      assert.equal(builder.getConfig().instructions.length, 2);
+    });
+  });
+
+  describe("getTransactionMessage", () => {
+    test("returns null when not prepared", () => {
+      const builder = createTransactionBuilder({
+        client: mockClient,
+        feePayer,
+      });
+
+      assert.equal(builder.getTransactionMessage(), null);
+    });
+
+    test("returns null before preparation", () => {
+      const builder = createTransactionBuilder({
+        client: mockClient,
+        feePayer,
+      });
+
+      // Note: For functional version, we can't easily mock internal state
+      // This test confirms the initial state behavior
+      assert.equal(builder.getTransactionMessage(), null);
+    });
+  });
+
+  describe("functional-specific tests", () => {
+    describe("closure state isolation", () => {
+      test("multiple builders don't share state", () => {
+        const config = { client: mockClient, feePayer };
+        const builder1 = createTransactionBuilder(config);
+        const builder2 = createTransactionBuilder(config);
+        
+        builder1.add(transferInstruction);
+        builder2.add(memoInstruction);
+        
+        assert.equal(builder1.getConfig().instructions.length, 1);
+        assert.equal(builder2.getConfig().instructions.length, 1);
+        assert.equal(builder1.getConfig().instructions[0], transferInstruction);
+        assert.equal(builder2.getConfig().instructions[0], memoInstruction);
+      });
+
+      test("state mutations don't affect other instances", () => {
+        const config = { client: mockClient, feePayer };
+        const builder1 = createTransactionBuilder(config);
+        const builder2 = createTransactionBuilder(config);
+        
+        builder1.setComputeLimit(300_000);
+        builder2.setPriorityFee(5000n);
+        
+        assert.equal(builder1.getConfig().computeLimit, 300_000);
+        assert.equal(builder1.getConfig().priorityFee, DEFAULTS.priorityFee);
+        assert.equal(builder2.getConfig().computeLimit, DEFAULTS.computeLimit);
+        assert.equal(builder2.getConfig().priorityFee, 5000n);
+      });
+    });
+  });
+});

--- a/packages/gill/src/__tests__/transaction-builder-comparison.test.ts
+++ b/packages/gill/src/__tests__/transaction-builder-comparison.test.ts
@@ -1,0 +1,318 @@
+import assert from "node:assert";
+
+import {
+  generateKeyPairSigner,
+  lamports,
+  type KeyPairSigner,
+  type Instruction,
+  type MicroLamports,
+} from "@solana/kit";
+import {
+  getTransferSolInstruction,
+  getAddMemoInstruction
+} from "../programs";
+import { TransactionBuilder } from "../core/transaction-builder";
+import { createTransactionBuilder } from "../core/create-transaction-builder";
+import { createSolanaClient } from "../core/create-solana-client";
+import type { SolanaClient } from "../types/rpc";
+
+describe("TransactionBuilder Comparison: Class vs Functional", () => {
+  let feePayer: KeyPairSigner;
+  let recipient: KeyPairSigner;
+  let mockClient: SolanaClient;
+  let transferInstruction: Instruction;
+  let memoInstruction: Instruction;
+
+  beforeAll(async () => {
+    feePayer = await generateKeyPairSigner();
+    recipient = await generateKeyPairSigner();
+
+    mockClient = createSolanaClient({
+      urlOrMoniker: "localnet",
+    });
+
+    transferInstruction = getTransferSolInstruction({
+      source: feePayer,
+      destination: recipient.address,
+      amount: lamports(1_000_000n),
+    });
+
+    memoInstruction = getAddMemoInstruction({
+      memo: "Hello, world!",
+    });
+  });
+
+  describe("API compatibility", () => {
+    test("identical default configuration", () => {
+      const config = { client: mockClient, feePayer };
+      
+      const classBuilder = new TransactionBuilder(config);
+      const funcBuilder = createTransactionBuilder(config);
+      
+      const classConfig = classBuilder.getConfig();
+      const funcConfig = funcBuilder.getConfig();
+      
+      assert.equal(classConfig.feePayer, funcConfig.feePayer);
+      assert.equal(classConfig.computeLimit, funcConfig.computeLimit);
+      assert.equal(classConfig.priorityFee, funcConfig.priorityFee);
+      assert.equal(classConfig.instructions.length, funcConfig.instructions.length);
+      assert.equal(classConfig.isPrepared, funcConfig.isPrepared);
+      assert.equal(classConfig.version, funcConfig.version);
+    });
+
+    test("identical custom configuration", () => {
+      const config = {
+        client: mockClient,
+        feePayer,
+        computeLimit: 300_000,
+        priorityFee: 2000n as MicroLamports,
+        version: 0 as const,
+      };
+      
+      const classBuilder = new TransactionBuilder(config);
+      const funcBuilder = createTransactionBuilder(config);
+      
+      const classConfig = classBuilder.getConfig();
+      const funcConfig = funcBuilder.getConfig();
+      
+      assert.equal(classConfig.computeLimit, funcConfig.computeLimit);
+      assert.equal(classConfig.priorityFee, funcConfig.priorityFee);
+      assert.equal(classConfig.version, funcConfig.version);
+    });
+
+    test("identical instruction adding behavior", () => {
+      const config = { client: mockClient, feePayer };
+      
+      const classBuilder = new TransactionBuilder(config);
+      const funcBuilder = createTransactionBuilder(config);
+      
+      // Add single instruction
+      classBuilder.add(transferInstruction);
+      funcBuilder.add(transferInstruction);
+      
+      assert.equal(classBuilder.getConfig().instructions.length, 1);
+      assert.equal(funcBuilder.getConfig().instructions.length, 1);
+      assert.equal(classBuilder.getConfig().instructions[0], transferInstruction);
+      assert.equal(funcBuilder.getConfig().instructions[0], transferInstruction);
+      
+      // Add multiple instructions
+      classBuilder.addMany([memoInstruction]);
+      funcBuilder.addMany([memoInstruction]);
+      
+      assert.equal(classBuilder.getConfig().instructions.length, 2);
+      assert.equal(funcBuilder.getConfig().instructions.length, 2);
+    });
+
+    test("identical chaining behavior", () => {
+      const config = { client: mockClient, feePayer };
+      
+      const classBuilder = new TransactionBuilder(config);
+      const funcBuilder = createTransactionBuilder(config);
+      
+      // Test method chaining
+      const classResult = classBuilder
+        .add(transferInstruction)
+        .setComputeLimit(250_000)
+        .setPriorityFee(1500n);
+        
+      const funcResult = funcBuilder
+        .add(transferInstruction)
+        .setComputeLimit(250_000)
+        .setPriorityFee(1500n);
+      
+      // Both should return themselves for chaining
+      assert.equal(classResult, classBuilder);
+      assert.equal(funcResult, funcBuilder);
+      
+      // Configurations should be identical
+      const classConfig = classBuilder.getConfig();
+      const funcConfig = funcBuilder.getConfig();
+      
+      assert.equal(classConfig.computeLimit, funcConfig.computeLimit);
+      assert.equal(classConfig.priorityFee, funcConfig.priorityFee);
+      assert.equal(classConfig.instructions.length, funcConfig.instructions.length);
+    });
+
+    test("identical error messages for validation", () => {
+      const config = { client: mockClient, feePayer };
+      
+      const classBuilder = new TransactionBuilder(config);
+      const funcBuilder = createTransactionBuilder(config);
+      
+      // Test negative compute limit
+      assert.throws(
+        () => classBuilder.setComputeLimit(-1),
+        /Compute limit cannot be negative/
+      );
+      assert.throws(
+        () => funcBuilder.setComputeLimit(-1),
+        /Compute limit cannot be negative/
+      );
+      
+      // Test negative priority fee
+      assert.throws(
+        () => classBuilder.setPriorityFee(-1n),
+        /Priority fee cannot be negative/
+      );
+      assert.throws(
+        () => funcBuilder.setPriorityFee(-1n),
+        /Priority fee cannot be negative/
+      );
+    });
+
+    test("identical reset behavior", () => {
+      const config = { client: mockClient, feePayer };
+      
+      const classBuilder = new TransactionBuilder(config);
+      const funcBuilder = createTransactionBuilder(config);
+      
+      // Add instructions and modify settings
+      classBuilder.add(transferInstruction).setComputeLimit(300_000);
+      funcBuilder.add(transferInstruction).setComputeLimit(300_000);
+      
+      assert.equal(classBuilder.getConfig().instructions.length, 1);
+      assert.equal(funcBuilder.getConfig().instructions.length, 1);
+      
+      // Reset both
+      classBuilder.reset();
+      funcBuilder.reset();
+      
+      const classConfig = classBuilder.getConfig();
+      const funcConfig = funcBuilder.getConfig();
+      
+      assert.equal(classConfig.instructions.length, 0);
+      assert.equal(funcConfig.instructions.length, 0);
+      assert.equal(classConfig.isPrepared, false);
+      assert.equal(funcConfig.isPrepared, false);
+      assert.equal(classBuilder.getTransactionMessage(), null);
+      assert.equal(funcBuilder.getTransactionMessage(), null);
+    });
+
+    test("identical error handling for prepare edge cases", async () => {
+      const config = { client: mockClient, feePayer };
+      
+      // Test prepare with no instructions
+      const classBuilder1 = new TransactionBuilder(config);
+      const funcBuilder1 = createTransactionBuilder(config);
+      
+      await assert.rejects(
+        () => classBuilder1.prepare(),
+        /Cannot prepare transaction with no instructions/
+      );
+      await assert.rejects(
+        () => funcBuilder1.prepare(),
+        /Cannot prepare transaction with no instructions/
+      );
+    });
+
+    test("identical error handling for sign/send without prepare", async () => {
+      const config = { client: mockClient, feePayer };
+      
+      const classBuilder = new TransactionBuilder(config);
+      const funcBuilder = createTransactionBuilder(config);
+      
+      // Test sign without prepare
+      await assert.rejects(
+        () => classBuilder.sign(),
+        /Transaction must be prepared before signing/
+      );
+      await assert.rejects(
+        () => funcBuilder.sign(),
+        /Transaction must be prepared before signing/
+      );
+      
+      // Test sendAndConfirm without prepare
+      await assert.rejects(
+        () => classBuilder.sendAndConfirm(),
+        /Transaction must be prepared before sending/
+      );
+      await assert.rejects(
+        () => funcBuilder.sendAndConfirm(),
+        /Transaction must be prepared before sending/
+      );
+    });
+  });
+
+  describe("implementation differences", () => {
+    test("class vs functional instantiation", () => {
+      const config = { client: mockClient, feePayer };
+      
+      // Class instantiation
+      const classBuilder = new TransactionBuilder(config);
+      assert.ok(classBuilder instanceof TransactionBuilder);
+      
+      // Functional instantiation
+      const funcBuilder = createTransactionBuilder(config);
+      assert.ok(typeof funcBuilder === 'object');
+      assert.ok('add' in funcBuilder);
+      assert.ok('prepare' in funcBuilder);
+      
+      // Should not be instance of TransactionBuilder class
+      assert.ok(!(funcBuilder instanceof TransactionBuilder));
+    });
+
+    test("static create method vs factory function", () => {
+      const config = { client: mockClient, feePayer };
+      
+      // Class static method
+      const classBuilder1 = TransactionBuilder.create(config);
+      const classBuilder2 = new TransactionBuilder(config);
+      
+      // Both class approaches should create instances
+      assert.ok(classBuilder1 instanceof TransactionBuilder);
+      assert.ok(classBuilder2 instanceof TransactionBuilder);
+      
+      // Functional approach
+      const funcBuilder = createTransactionBuilder(config);
+      assert.ok(!(funcBuilder instanceof TransactionBuilder));
+      
+      // But all should have identical APIs
+      assert.equal(typeof classBuilder1.add, 'function');
+      assert.equal(typeof classBuilder2.add, 'function');
+      assert.equal(typeof funcBuilder.add, 'function');
+    });
+
+    test("state isolation in functional version", () => {
+      const config = { client: mockClient, feePayer };
+      
+      // Create multiple functional builders
+      const funcBuilder1 = createTransactionBuilder(config);
+      const funcBuilder2 = createTransactionBuilder(config);
+      
+      // Modify each independently
+      funcBuilder1.add(transferInstruction).setComputeLimit(300_000);
+      funcBuilder2.add(memoInstruction).setPriorityFee(2000n);
+      
+      // Should have isolated state
+      const config1 = funcBuilder1.getConfig();
+      const config2 = funcBuilder2.getConfig();
+      
+      assert.equal(config1.instructions.length, 1);
+      assert.equal(config2.instructions.length, 1);
+      assert.equal(config1.instructions[0], transferInstruction);
+      assert.equal(config2.instructions[0], memoInstruction);
+      assert.equal(config1.computeLimit, 300_000);
+      assert.equal(config2.computeLimit, 200_000); // default
+      assert.equal(config1.priorityFee, 1n); // default
+      assert.equal(config2.priorityFee, 2000n);
+    });
+  });
+
+  describe("memory and reference behavior", () => {
+    test("method references are bound in functional version", () => {
+      const config = { client: mockClient, feePayer };
+      const funcBuilder = createTransactionBuilder(config);
+      
+      // Extract method reference
+      const addMethod = funcBuilder.add;
+      const getConfigMethod = funcBuilder.getConfig;
+      
+      // Should still work when called separately
+      addMethod(transferInstruction);
+      const configAfterAdd = getConfigMethod();
+      
+      assert.equal(configAfterAdd.instructions.length, 1);
+      assert.equal(configAfterAdd.instructions[0], transferInstruction);
+    });
+  });
+});

--- a/packages/gill/src/__tests__/transaction-builder.ts
+++ b/packages/gill/src/__tests__/transaction-builder.ts
@@ -1,0 +1,346 @@
+import assert from "node:assert";
+
+import {
+  generateKeyPairSigner,
+  lamports,
+  type KeyPairSigner,
+  type Instruction,
+  type MicroLamports,
+} from "@solana/kit";
+import { 
+  getTransferSolInstruction,
+  getAddMemoInstruction
+ } from "../programs";
+import { TransactionBuilder } from "../core/transaction-builder";
+import { createSolanaClient } from "../core/create-solana-client";
+import type { SolanaClient } from "../types/rpc";
+
+const DEFAULTS = {
+  computeLimit: 200_000,
+  priorityFee: 1n,
+}
+
+describe("TransactionBuilder", () => {
+  let feePayer: KeyPairSigner;
+  let recipient: KeyPairSigner;
+  let mockClient: SolanaClient;
+  let transferInstruction: Instruction;
+  let memoInstruction: Instruction;
+
+  beforeAll(async () => {
+    feePayer = await generateKeyPairSigner();
+    recipient = await generateKeyPairSigner();
+
+    mockClient = createSolanaClient({
+      urlOrMoniker: "localnet",
+    });
+
+    transferInstruction = getTransferSolInstruction({
+      source: feePayer,
+      destination: recipient.address,
+      amount: lamports(1_000_000n),
+    });
+
+    memoInstruction = getAddMemoInstruction({
+      memo: "Hello, world!",
+    });
+  });
+
+  describe("constructor", () => {
+    test("creates a builder with default configuration", () => {
+      const builder = new TransactionBuilder({
+        client: mockClient,
+        feePayer,
+      });
+
+      const config = builder.getConfig();
+      assert.equal(config.feePayer, feePayer.address);
+      assert.equal(config.computeLimit, DEFAULTS.computeLimit);
+      assert.equal(config.priorityFee, DEFAULTS.priorityFee);
+      assert.equal(config.instructions.length, 0);
+      assert.equal(config.isPrepared, false);
+    });
+
+    test("creates a builder with custom configuration", () => {
+      const computeLimit = 200_000;
+      const priorityFee = 5000n as MicroLamports;
+      const builder = new TransactionBuilder({
+        client: mockClient,
+        feePayer,
+        computeLimit,
+        priorityFee,
+      });
+
+      const config = builder.getConfig();
+      assert.equal(config.computeLimit, computeLimit);
+      assert.equal(config.priorityFee, priorityFee);
+    });
+
+    test("static create method works", () => {
+      const builder = TransactionBuilder.create({
+        client: mockClient,
+        feePayer,
+      });
+
+      assert.ok(builder instanceof TransactionBuilder);
+    });
+  });
+
+  describe("add instructions", () => {
+    test("adds a single instruction", () => {
+      const builder = new TransactionBuilder({
+        client: mockClient,
+        feePayer,
+      });
+
+      builder.add(transferInstruction);
+      assert.equal(builder.getConfig().instructions.length, 1);
+    });
+
+    test("adds multiple instructions with addMany", () => {
+      const builder = new TransactionBuilder({
+        client: mockClient,
+        feePayer,
+      });
+
+      const instructions = [transferInstruction, memoInstruction];
+      builder.addMany(instructions);
+      assert.equal(builder.getConfig().instructions.length, 2);
+      assert.equal(builder.getConfig().instructions[0], transferInstruction);
+      assert.equal(builder.getConfig().instructions[1], memoInstruction);
+    });
+
+    test("supports method chaining", () => {
+      const computeLimit = 200_000;
+      const priorityFee = 1000n as MicroLamports;
+      const beforeAddInstructions = new TransactionBuilder({
+        client: mockClient,
+        feePayer,
+      });
+
+      assert.equal(beforeAddInstructions.getConfig().instructions.length, 0);
+
+      const beforeSetComputeAndPriorityFee = beforeAddInstructions
+        .add(transferInstruction)
+        .add(memoInstruction)
+
+      assert.equal(beforeSetComputeAndPriorityFee.getConfig().instructions.length, 2);
+      assert.equal(beforeSetComputeAndPriorityFee.getConfig().instructions[0], transferInstruction);
+      assert.equal(beforeSetComputeAndPriorityFee.getConfig().instructions[1], memoInstruction);
+      assert.equal(beforeSetComputeAndPriorityFee.getConfig().computeLimit, DEFAULTS.computeLimit);
+      assert.equal(beforeSetComputeAndPriorityFee.getConfig().priorityFee, DEFAULTS.priorityFee);
+
+      const afterSetComputeAndPriorityFee = beforeSetComputeAndPriorityFee
+        .setComputeLimit(computeLimit)
+        .setPriorityFee(priorityFee);
+
+      assert.equal(afterSetComputeAndPriorityFee.getConfig().instructions.length, 2);
+      assert.equal(afterSetComputeAndPriorityFee.getConfig().instructions[0], transferInstruction);
+      assert.equal(afterSetComputeAndPriorityFee.getConfig().instructions[1], memoInstruction);
+      assert.equal(afterSetComputeAndPriorityFee.getConfig().computeLimit, computeLimit);
+      assert.equal(afterSetComputeAndPriorityFee.getConfig().priorityFee, priorityFee);
+    });
+
+    test("throws error when adding instructions after prepare", async () => {
+      const builder = new TransactionBuilder({
+        client: mockClient,
+        feePayer,
+      });
+
+      builder.add(transferInstruction);
+
+      // Mock the prepare method to avoid actual RPC calls
+      builder["transactionMessage"] = {} as any;
+
+      assert.throws(
+        () => builder.add(transferInstruction),
+        /Cannot add instructions after prepare/
+      );
+    });
+  });
+
+  describe("setters", () => {
+    test("sets compute limit", () => {
+      const builder = new TransactionBuilder({
+        client: mockClient,
+        feePayer,
+      });
+
+      builder.setComputeLimit(300_000);
+      assert.equal(builder.getConfig().computeLimit, 300_000);
+    });
+
+    test("sets priority fee with different types", () => {
+      const builder = new TransactionBuilder({
+        client: mockClient,
+        feePayer,
+      });
+
+      // Test with number
+      builder.setPriorityFee(1000);
+      assert.equal(builder.getConfig().priorityFee, 1000n);
+
+      // Test with bigint
+      builder.setPriorityFee(2000n);
+      assert.equal(builder.getConfig().priorityFee, 2000n);
+
+      // Test with MicroLamports
+      builder.setPriorityFee(3000n as MicroLamports);
+      assert.equal(builder.getConfig().priorityFee, 3000n);
+    });
+
+    test("throws error when modifying after prepare", () => {
+      const builder = new TransactionBuilder({
+        client: mockClient,
+        feePayer,
+      });
+
+      builder["transactionMessage"] = {} as any;
+
+      assert.throws(
+        () => builder.setComputeLimit(200_000),
+        /Cannot modify compute limit after prepare/
+      );
+
+      assert.throws(
+        () => builder.setPriorityFee(1000n),
+        /Cannot modify priority fee after prepare/
+      );
+    });
+
+    test("throws error when setting compute limit to negative", () => {
+      const builder = new TransactionBuilder({
+        client: mockClient,
+        feePayer,
+      });
+
+      assert.throws(
+        () => builder.setComputeLimit(-1),
+        /Compute limit cannot be negative/
+      );
+    });
+
+    test("throws error when setting priority fee to negative", () => {
+      const builder = new TransactionBuilder({
+        client: mockClient,
+        feePayer,
+      });
+
+      assert.throws(
+        () => builder.setPriorityFee(-1n),
+        /Priority fee cannot be negative/
+      );
+    });
+  });
+
+  describe("prepare", () => {
+    test("throws error when no instructions added", async () => {
+      const builder = new TransactionBuilder({
+        client: mockClient,
+        feePayer,
+      });
+
+      await assert.rejects(
+        async () => await builder.prepare(),
+        /Cannot prepare transaction with no instructions/
+      );
+    });
+
+    test("throws error when already prepared", async () => {
+      const builder = new TransactionBuilder({
+        client: mockClient,
+        feePayer,
+      });
+
+      builder.add(transferInstruction);
+      builder["transactionMessage"] = {} as any;
+
+      await assert.rejects(
+        async () => await builder.prepare(),
+        /Transaction has already been prepared/
+      );
+    });
+
+  });
+
+  describe("sign and send", () => {
+    test("throws error when signing without prepare", async () => {
+      const builder = new TransactionBuilder({
+        client: mockClient,
+        feePayer,
+      });
+
+      await assert.rejects(
+        async () => await builder.sign(),
+        /Transaction must be prepared before signing/
+      );
+    });
+
+    test("throws error when sending without prepare", async () => {
+      const builder = new TransactionBuilder({
+        client: mockClient,
+        feePayer,
+      });
+
+      await assert.rejects(
+        async () => await builder.sendAndConfirm(),
+        /Transaction must be prepared before sending/
+      );
+    });
+  });
+
+  describe("reset", () => {
+    test("resets the builder state", () => {
+      const builder = new TransactionBuilder({
+        client: mockClient,
+        feePayer,
+      });
+
+      builder.add(transferInstruction);
+      builder.add(transferInstruction);
+      assert.equal(builder.getConfig().instructions.length, 2);
+
+      builder.reset();
+      assert.equal(builder.getConfig().instructions.length, 0);
+      assert.equal(builder.getConfig().isPrepared, false);
+      assert.equal(builder.getTransactionMessage(), null);
+    });
+
+    test("allows reuse after reset", () => {
+      const builder = new TransactionBuilder({
+        client: mockClient,
+        feePayer,
+      });
+
+      builder.add(transferInstruction);
+      builder.reset();
+      builder.add(transferInstruction);
+      builder.add(memoInstruction);
+
+      assert.equal(builder.getConfig().instructions.length, 2);
+    });
+  });
+
+  describe("getTransactionMessage", () => {
+    test("returns null when not prepared", () => {
+      const builder = new TransactionBuilder({
+        client: mockClient,
+        feePayer,
+      });
+
+      assert.equal(builder.getTransactionMessage(), null);
+    });
+
+    test("returns transaction message when prepared", () => {
+      const builder = new TransactionBuilder({
+        client: mockClient,
+        feePayer,
+      });
+
+      const mockMessage = { test: "message" } as any;
+      builder["transactionMessage"] = mockMessage;
+
+      assert.equal(builder.getTransactionMessage(), mockMessage);
+    });
+  });
+});

--- a/packages/gill/src/__tests__/transaction-builder.ts
+++ b/packages/gill/src/__tests__/transaction-builder.ts
@@ -7,10 +7,10 @@ import {
   type Instruction,
   type MicroLamports,
 } from "@solana/kit";
-import { 
+import {
   getTransferSolInstruction,
   getAddMemoInstruction
- } from "../programs";
+} from "../programs";
 import { TransactionBuilder } from "../core/transaction-builder";
 import { createSolanaClient } from "../core/create-solana-client";
 import type { SolanaClient } from "../types/rpc";
@@ -59,6 +59,7 @@ describe("TransactionBuilder", () => {
       assert.equal(config.priorityFee, DEFAULTS.priorityFee);
       assert.equal(config.instructions.length, 0);
       assert.equal(config.isPrepared, false);
+      assert.equal(config.version, 'legacy');
     });
 
     test("creates a builder with custom configuration", () => {
@@ -69,11 +70,13 @@ describe("TransactionBuilder", () => {
         feePayer,
         computeLimit,
         priorityFee,
+        version: 0,
       });
 
       const config = builder.getConfig();
       assert.equal(config.computeLimit, computeLimit);
       assert.equal(config.priorityFee, priorityFee);
+      assert.equal(config.version, 0);
     });
 
     test("static create method works", () => {

--- a/packages/gill/src/core/create-transaction-builder.ts
+++ b/packages/gill/src/core/create-transaction-builder.ts
@@ -1,0 +1,308 @@
+import {
+  signTransactionMessageWithSigners,
+  getSignatureFromTransaction,
+  type CompilableTransactionMessage,
+  type TransactionMessageWithBlockhashLifetime,
+  type Instruction,
+  type KeyPairSigner,
+  type Signature,
+  type MicroLamports,
+  type Commitment,
+  type FullySignedTransaction,
+  TransactionVersion,
+} from "@solana/kit";
+import type { SolanaClient } from "../types/rpc";
+import { debug } from "./debug";
+import { createTransaction } from "./create-transaction";
+import { prepareTransaction, type PrepareTransactionConfig } from "./prepare-transaction";
+
+export interface FunctionalTransactionBuilderConfig {
+  client: SolanaClient;
+  feePayer: KeyPairSigner;
+  computeLimit?: number;
+  priorityFee?: MicroLamports | bigint | number;
+  version?: TransactionVersion;
+}
+
+export interface FunctionalSimpleSendAndConfirmConfig {
+  commitment?: Commitment;
+  preflightCommitment?: Commitment;
+  skipPreflight?: boolean;
+  abortSignal?: AbortSignal;
+}
+
+interface TransactionBuilderState {
+  readonly config: {
+    client: SolanaClient;
+    feePayer: KeyPairSigner;
+    computeLimit: number;
+    priorityFee: MicroLamports;
+    version: TransactionVersion;
+  };
+  instructions: Instruction[];
+  transactionMessage: (CompilableTransactionMessage & TransactionMessageWithBlockhashLifetime) | null;
+  isPrepareCalled: boolean;
+}
+
+const DEFAULT_PREPARE_CONFIG = {
+  computeUnitLimitMultiplier: 1.1,
+  computeUnitLimitReset: true,
+  blockhashReset: true,
+};
+
+const DEFAULT_COMPUTE_LIMIT = 200_000;
+const DEFAULT_PRIORITY_FEE = 1n;
+const DEFAULT_VERSION = 'legacy';
+
+export interface FunctionalTransactionBuilder {
+  add(instruction: Instruction): FunctionalTransactionBuilder;
+  addMany(instructions: Instruction[]): FunctionalTransactionBuilder;
+  setComputeLimit(limit: number): FunctionalTransactionBuilder;
+  setPriorityFee(fee: MicroLamports | bigint | number): FunctionalTransactionBuilder;
+  prepare(config?: Partial<PrepareTransactionConfig<CompilableTransactionMessage>>): Promise<FunctionalTransactionBuilder>;
+  sign(): Promise<FullySignedTransaction>;
+  sendAndConfirm(sendAndConfirmConfig?: FunctionalSimpleSendAndConfirmConfig): Promise<Signature>;
+  prepareAndSendAndConfirm(
+    sendAndConfirmConfig?: FunctionalSimpleSendAndConfirmConfig,
+    prepareConfig?: Partial<PrepareTransactionConfig<CompilableTransactionMessage>>
+  ): Promise<Signature>;
+  getConfig(): {
+    feePayer: string;
+    computeLimit: number;
+    priorityFee: MicroLamports;
+    instructions: Instruction[];
+    isPrepared: boolean;
+    version: TransactionVersion;
+  };
+  reset(): FunctionalTransactionBuilder;
+  getTransactionMessage(): (CompilableTransactionMessage & TransactionMessageWithBlockhashLifetime) | null;
+}
+
+function validateComputeLimit(limit: number): number {
+  if (limit < 0) {
+    throw new Error("Compute limit cannot be negative.");
+  }
+  return limit;
+}
+
+function getMicroLamports(value: MicroLamports | bigint | number): MicroLamports {
+  if (typeof value === "number") {
+    if (value < 0) {
+      throw new Error("Priority fee cannot be negative.");
+    }
+    return BigInt(value) as MicroLamports;
+  }
+  if (value < 0n) {
+    throw new Error("Priority fee cannot be negative.");
+  }
+  return value as MicroLamports;
+}
+
+function createInitialState(config: FunctionalTransactionBuilderConfig): TransactionBuilderState {
+  return {
+    config: {
+      client: config.client,
+      feePayer: config.feePayer,
+      computeLimit: validateComputeLimit(config.computeLimit ?? DEFAULT_COMPUTE_LIMIT),
+      priorityFee: getMicroLamports(config.priorityFee ?? DEFAULT_PRIORITY_FEE),
+      version: config.version ?? DEFAULT_VERSION,
+    },
+    instructions: [],
+    transactionMessage: null,
+    isPrepareCalled: false,
+  };
+}
+
+function createAddMethod(state: TransactionBuilderState, builder: FunctionalTransactionBuilder) {
+  return function add(instruction: Instruction): FunctionalTransactionBuilder {
+    if (state.transactionMessage) {
+      throw new Error(
+        "Cannot add instructions after prepare() has been called. Create a new TransactionBuilder or reset the builder."
+      );
+    }
+
+    state.instructions.push(instruction);
+    debug(`Added instruction to transaction. Total instructions: ${state.instructions.length}`, "debug");
+    return builder;
+  };
+}
+
+function createAddManyMethod(state: TransactionBuilderState, builder: FunctionalTransactionBuilder) {
+  return function addMany(instructions: Instruction[]): FunctionalTransactionBuilder {
+    if (state.transactionMessage) {
+      throw new Error(
+        "Cannot add instructions after prepare() has been called. Create a new TransactionBuilder or reset the builder."
+      );
+    }
+
+    state.instructions.push(...instructions);
+    debug(`Added ${instructions.length} instructions to transaction. Total: ${state.instructions.length}`, "debug");
+    return builder;
+  };
+}
+
+function createSetComputeLimitMethod(state: TransactionBuilderState, builder: FunctionalTransactionBuilder) {
+  return function setComputeLimit(limit: number): FunctionalTransactionBuilder {
+    if (state.transactionMessage) {
+      throw new Error("Cannot modify compute limit after prepare() has been called.");
+    }
+
+    state.config.computeLimit = validateComputeLimit(limit);
+    debug(`Set compute unit limit to ${limit}`, "debug");
+    return builder;
+  };
+}
+
+function createSetPriorityFeeMethod(state: TransactionBuilderState, builder: FunctionalTransactionBuilder) {
+  return function setPriorityFee(fee: MicroLamports | bigint | number): FunctionalTransactionBuilder {
+    if (state.transactionMessage) {
+      throw new Error("Cannot modify priority fee after prepare() has been called.");
+    }
+
+    state.config.priorityFee = getMicroLamports(fee);
+    debug(`Set priority fee to ${state.config.priorityFee} microlamports`, "debug");
+    return builder;
+  };
+}
+
+function createPrepareMethod(state: TransactionBuilderState, builder: FunctionalTransactionBuilder) {
+  return async function prepare(config?: Partial<PrepareTransactionConfig<CompilableTransactionMessage>>): Promise<FunctionalTransactionBuilder> {
+    if (state.instructions.length === 0) {
+      throw new Error("Cannot prepare transaction with no instructions. Use add() to add instructions first.");
+    }
+
+    if (state.transactionMessage) {
+      throw new Error(
+        "Transaction has already been prepared. Create a new TransactionBuilder to build another transaction."
+      );
+    }
+
+    debug(`Preparing transaction with ${state.instructions.length} instructions`, "info");
+
+    let unpreparedTransaction = createTransaction({
+      version: state.config.version,
+      feePayer: state.config.feePayer,
+      instructions: state.instructions,
+      computeUnitLimit: state.config.computeLimit,
+      computeUnitPrice: state.config.priorityFee,
+    });
+
+    const prepareConfig = {
+      transaction: unpreparedTransaction,
+      rpc: state.config.client.rpc,
+      computeUnitLimitMultiplier: config?.computeUnitLimitMultiplier ?? DEFAULT_PREPARE_CONFIG.computeUnitLimitMultiplier,
+      computeUnitLimitReset: config?.computeUnitLimitReset ?? DEFAULT_PREPARE_CONFIG.computeUnitLimitReset,
+      blockhashReset: config?.blockhashReset ?? DEFAULT_PREPARE_CONFIG.blockhashReset,
+    } as unknown as PrepareTransactionConfig<CompilableTransactionMessage>;
+
+    state.transactionMessage = await prepareTransaction(prepareConfig);
+    state.isPrepareCalled = true;
+    debug("Transaction prepared successfully", "info");
+
+    return builder;
+  };
+}
+
+function createSignMethod(state: TransactionBuilderState) {
+  return async function sign(): Promise<FullySignedTransaction> {
+    if (!state.transactionMessage) {
+      throw new Error("Transaction must be prepared before signing. Call prepare() first.");
+    }
+
+    debug("Signing transaction", "debug");
+    const signedTransaction = await signTransactionMessageWithSigners(state.transactionMessage);
+    const signature = getSignatureFromTransaction(signedTransaction);
+    debug(`Transaction signed. Signature: ${signature}`, "info");
+
+    return signedTransaction;
+  };
+}
+
+function createSendAndConfirmMethod(state: TransactionBuilderState) {
+  return async function sendAndConfirm(sendAndConfirmConfig?: FunctionalSimpleSendAndConfirmConfig): Promise<Signature> {
+    const { commitment = "confirmed", preflightCommitment = "confirmed", skipPreflight = false, abortSignal } = sendAndConfirmConfig ?? {};
+    if (!state.transactionMessage) {
+      throw new Error("Transaction must be prepared before sending. Call prepare() first.");
+    }
+
+    debug("Sending and confirming transaction", "info");
+
+    const signature = await state.config.client.sendAndConfirmTransaction(state.transactionMessage, {
+      commitment,
+      preflightCommitment,
+      skipPreflight,
+      abortSignal,
+    });
+
+    debug(`Transaction confirmed. ${signature}`, "info");
+
+    return signature;
+  };
+}
+
+function createPrepareAndSendAndConfirmMethod(_state: TransactionBuilderState, builder: FunctionalTransactionBuilder) {
+  return async function prepareAndSendAndConfirm(
+    sendAndConfirmConfig?: FunctionalSimpleSendAndConfirmConfig,
+    prepareConfig?: Partial<PrepareTransactionConfig<CompilableTransactionMessage>>
+  ): Promise<Signature> {
+    await builder.prepare(prepareConfig);
+    return builder.sendAndConfirm(sendAndConfirmConfig);
+  };
+}
+
+function createGetConfigMethod(state: TransactionBuilderState) {
+  return function getConfig(): {
+    feePayer: string;
+    computeLimit: number;
+    priorityFee: MicroLamports;
+    instructions: Instruction[];
+    isPrepared: boolean;
+    version: TransactionVersion;
+  } {
+    return {
+      feePayer: state.config.feePayer.address,
+      computeLimit: state.config.computeLimit,
+      priorityFee: state.config.priorityFee,
+      instructions: state.instructions,
+      isPrepared: state.transactionMessage !== null,
+      version: state.config.version,
+    };
+  };
+}
+
+function createResetMethod(state: TransactionBuilderState, builder: FunctionalTransactionBuilder) {
+  return function reset(): FunctionalTransactionBuilder {
+    state.instructions = [];
+    state.transactionMessage = null;
+    state.isPrepareCalled = false;
+    debug("Transaction builder reset", "debug");
+    return builder;
+  };
+}
+
+function createGetTransactionMessageMethod(state: TransactionBuilderState) {
+  return function getTransactionMessage(): (CompilableTransactionMessage & TransactionMessageWithBlockhashLifetime) | null {
+    return state.transactionMessage;
+  };
+}
+
+export function createTransactionBuilder(config: FunctionalTransactionBuilderConfig): FunctionalTransactionBuilder {
+  const state = createInitialState(config);
+  
+  const builder: FunctionalTransactionBuilder = {} as FunctionalTransactionBuilder;
+  
+  // Create methods with access to state and builder
+  builder.add = createAddMethod(state, builder);
+  builder.addMany = createAddManyMethod(state, builder);
+  builder.setComputeLimit = createSetComputeLimitMethod(state, builder);
+  builder.setPriorityFee = createSetPriorityFeeMethod(state, builder);
+  builder.prepare = createPrepareMethod(state, builder);
+  builder.sign = createSignMethod(state);
+  builder.sendAndConfirm = createSendAndConfirmMethod(state);
+  builder.prepareAndSendAndConfirm = createPrepareAndSendAndConfirmMethod(state, builder);
+  builder.getConfig = createGetConfigMethod(state);
+  builder.reset = createResetMethod(state, builder);
+  builder.getTransactionMessage = createGetTransactionMessageMethod(state);
+  
+  return builder;
+}

--- a/packages/gill/src/core/index.ts
+++ b/packages/gill/src/core/index.ts
@@ -17,3 +17,4 @@ export * from "./simulate-transaction";
 export * from "./get-oldest-signature";
 export * from "./insert-reference-key";
 export * from "./create-codama-config";
+export * from "./transaction-builder";

--- a/packages/gill/src/core/index.ts
+++ b/packages/gill/src/core/index.ts
@@ -18,3 +18,4 @@ export * from "./get-oldest-signature";
 export * from "./insert-reference-key";
 export * from "./create-codama-config";
 export * from "./transaction-builder";
+export * from "./create-transaction-builder";

--- a/packages/gill/src/core/prepare-transaction.ts
+++ b/packages/gill/src/core/prepare-transaction.ts
@@ -2,7 +2,7 @@ import { COMPUTE_BUDGET_PROGRAM_ADDRESS, getSetComputeUnitLimitInstruction } fro
 import type {
   CompilableTransactionMessage,
   GetLatestBlockhashApi,
-  ITransactionMessageWithFeePayer,
+  TransactionMessageWithFeePayer,
   Rpc,
   SimulateTransactionApi,
   TransactionMessage,
@@ -11,16 +11,15 @@ import type {
 import {
   appendTransactionMessageInstruction,
   assertIsTransactionMessageWithBlockhashLifetime,
-  getComputeUnitEstimateForTransactionMessageFactory,
   setTransactionMessageLifetimeUsingBlockhash,
 } from "@solana/kit";
-import { isSetComputeLimitInstruction } from "../programs/compute-budget";
+import { isSetComputeLimitInstruction, estimateComputeUnitLimitFactory } from "../programs/compute-budget";
 import { transactionToBase64WithSigners } from "./base64-to-transaction";
 import { debug, isDebugEnabled } from "./debug";
 
 type PrepareCompilableTransactionMessage =
   | CompilableTransactionMessage
-  | (ITransactionMessageWithFeePayer & TransactionMessage);
+  | (TransactionMessageWithFeePayer & TransactionMessage);
 
 export type PrepareTransactionConfig<TMessage extends PrepareCompilableTransactionMessage> = {
   /**
@@ -82,7 +81,7 @@ export async function prepareTransaction<TMessage extends PrepareCompilableTrans
 
   // set a compute unit limit instruction
   if (computeBudgetIndex.limit < 0 || config.computeUnitLimitReset) {
-    const units = await getComputeUnitEstimateForTransactionMessageFactory({ rpc: config.rpc })(config.transaction);
+    const units = await estimateComputeUnitLimitFactory({ rpc: config.rpc })(config.transaction);
     debug(`Obtained compute units from simulation: ${units}`, "debug");
     const ix = getSetComputeUnitLimitInstruction({
       units: units * config.computeUnitLimitMultiplier,

--- a/packages/gill/src/core/transaction-builder.ts
+++ b/packages/gill/src/core/transaction-builder.ts
@@ -1,0 +1,240 @@
+import {
+  pipe,
+  createTransactionMessage,
+  setTransactionMessageFeePayerSigner,
+  appendTransactionMessageInstructions,
+  signTransactionMessageWithSigners,
+  getSignatureFromTransaction,
+  type CompilableTransactionMessage,
+  type TransactionMessageWithBlockhashLifetime,
+  type Instruction,
+  type KeyPairSigner,
+  type Signature,
+  type MicroLamports,
+  type Commitment,
+  type FullySignedTransaction,
+} from "@solana/kit";
+import {
+  updateOrAppendSetComputeUnitLimitInstruction,
+  updateOrAppendSetComputeUnitPriceInstruction,
+} from "@solana-program/compute-budget";
+import type { SolanaClient } from "../types/rpc";
+import { debug } from "./debug";
+import { prepareTransaction, type PrepareTransactionConfig } from "./prepare-transaction";
+
+export interface TransactionBuilderConfig {
+  client: SolanaClient;
+  feePayer: KeyPairSigner;
+  computeLimit?: number;
+  priorityFee?: MicroLamports | bigint | number;
+}
+
+export interface SimpleSendAndConfirmConfig {
+  commitment?: Commitment;
+  preflightCommitment?: Commitment;
+  skipPreflight?: boolean;
+  abortSignal?: AbortSignal;
+}
+
+const DEFAULT_PREPARE_CONFIG = {
+  computeUnitLimitMultiplier: 1.1,
+  computeUnitLimitReset: true,
+  blockhashReset: true,
+};
+
+const DEFAULT_COMPUTE_LIMIT = 200_000;
+
+const DEFAULT_PRIORITY_FEE = 1n;
+
+
+export class TransactionBuilder {
+  private client: SolanaClient;
+  private feePayer: KeyPairSigner;
+  private instructions: Instruction[] = [];
+  private computeLimit: number;
+  private priorityFee: MicroLamports;
+  private transactionMessage: (CompilableTransactionMessage & TransactionMessageWithBlockhashLifetime) | null = null;
+
+  constructor(config: TransactionBuilderConfig) {
+    this.client = config.client;
+    this.feePayer = config.feePayer;
+    this.computeLimit = this.validateComputeLimit(config.computeLimit ?? DEFAULT_COMPUTE_LIMIT);
+    this.priorityFee = this.getMicroLamports(config.priorityFee ?? DEFAULT_PRIORITY_FEE);
+  }
+
+  static create(config: TransactionBuilderConfig): TransactionBuilder {
+    return new TransactionBuilder(config);
+  }
+
+  private getMicroLamports(value: MicroLamports | bigint | number): MicroLamports {
+    if (typeof value === "number") {
+      if (value < 0) {
+        throw new Error("Priority fee cannot be negative.");
+      }
+      return BigInt(value) as MicroLamports;
+    }
+    if (value < 0n) {
+      throw new Error("Priority fee cannot be negative.");
+    }
+    return value as MicroLamports;
+  }
+
+  add(instruction: Instruction): this {
+    if (this.transactionMessage) {
+      throw new Error(
+        "Cannot add instructions after prepare() has been called. Create a new TransactionBuilder or reset the builder."
+      );
+    }
+
+    this.instructions.push(instruction);
+    debug(`Added instruction to transaction. Total instructions: ${this.instructions.length}`, "debug");
+    return this;
+  }
+
+  addMany(instructions: Instruction[]): this {
+    if (this.transactionMessage) {
+      throw new Error(
+        "Cannot add instructions after prepare() has been called. Create a new TransactionBuilder or reset the builder."
+      );
+    }
+
+    this.instructions.push(...instructions);
+    debug(`Added ${instructions.length} instructions to transaction. Total: ${this.instructions.length}`, "debug");
+    return this;
+  }
+
+  setComputeLimit(limit: number): this {
+    if (this.transactionMessage) {
+      throw new Error("Cannot modify compute limit after prepare() has been called.");
+    }
+
+    this.computeLimit = this.validateComputeLimit(limit);
+    debug(`Set compute unit limit to ${limit}`, "debug");
+    return this;
+  }
+
+  private validateComputeLimit(limit: number): number {
+    if (limit < 0) {
+      throw new Error("Compute limit cannot be negative.");
+    }
+    return limit;
+  }
+
+  setPriorityFee(fee: MicroLamports | bigint | number): this {
+    if (this.transactionMessage) {
+      throw new Error("Cannot modify priority fee after prepare() has been called.");
+    }
+
+    this.priorityFee = this.getMicroLamports(fee);
+    debug(`Set priority fee to ${this.priorityFee} microlamports`, "debug");
+    return this;
+  }
+
+  async prepare(config?: Partial<PrepareTransactionConfig<CompilableTransactionMessage>>): Promise<this> {
+    if (this.instructions.length === 0) {
+      throw new Error("Cannot prepare transaction with no instructions. Use add() to add instructions first.");
+    }
+
+    if (this.transactionMessage) {
+      throw new Error(
+        "Transaction has already been prepared. Create a new TransactionBuilder to build another transaction."
+      );
+    }
+
+    debug(`Preparing transaction with ${this.instructions.length} instructions`, "info");
+
+    let transaction = pipe(
+      createTransactionMessage({ version: 0 }),
+      (msg) => setTransactionMessageFeePayerSigner(this.feePayer, msg),
+      (msg) => updateOrAppendSetComputeUnitLimitInstruction(this.computeLimit, msg),
+      (msg) => appendTransactionMessageInstructions(this.instructions, msg)
+    );
+
+    if (this.priorityFee > 0n) {
+      transaction = updateOrAppendSetComputeUnitPriceInstruction(this.priorityFee, transaction);
+    }
+
+    const compilableTransaction = transaction as unknown as CompilableTransactionMessage;
+
+    const prepareConfig: PrepareTransactionConfig<CompilableTransactionMessage> = {
+      transaction: compilableTransaction,
+      rpc: this.client.rpc,
+      computeUnitLimitMultiplier: config?.computeUnitLimitMultiplier ?? DEFAULT_PREPARE_CONFIG.computeUnitLimitMultiplier,
+      computeUnitLimitReset: config?.computeUnitLimitReset ?? DEFAULT_PREPARE_CONFIG.computeUnitLimitReset,
+      blockhashReset: config?.blockhashReset ?? DEFAULT_PREPARE_CONFIG.blockhashReset,
+    };
+
+    this.transactionMessage = await prepareTransaction(prepareConfig);
+    debug("Transaction prepared successfully", "info");
+
+    return this;
+  }
+
+  async sign(): Promise<FullySignedTransaction> {
+    if (!this.transactionMessage) {
+      throw new Error("Transaction must be prepared before signing. Call prepare() first.");
+    }
+
+    debug("Signing transaction", "debug");
+    const signedTransaction = await signTransactionMessageWithSigners(this.transactionMessage);
+    const signature = getSignatureFromTransaction(signedTransaction);
+    debug(`Transaction signed. Signature: ${signature}`, "info");
+
+    return signedTransaction;
+  }
+
+  async sendAndConfirm(sendAndConfirmConfig?: SimpleSendAndConfirmConfig): Promise<Signature> {
+    const { commitment = "confirmed", preflightCommitment = "confirmed", skipPreflight = false, abortSignal } = sendAndConfirmConfig ?? {};
+    if (!this.transactionMessage) {
+      throw new Error("Transaction must be prepared before sending. Call prepare() first.");
+    }
+
+    debug("Sending and confirming transaction", "info");
+
+    const signature = await this.client.sendAndConfirmTransaction(this.transactionMessage, {
+      commitment,
+      preflightCommitment,
+      skipPreflight,
+      abortSignal,
+    });
+
+    debug(`Transaction confirmed. ${signature}`, "info");
+
+    return signature;
+  }
+
+  async prepareAndSendAndConfirm(
+    sendAndConfirmConfig?: SimpleSendAndConfirmConfig,
+    prepareConfig?: Partial<PrepareTransactionConfig<CompilableTransactionMessage>>
+  ): Promise<Signature> {
+    await this.prepare(prepareConfig);
+    return this.sendAndConfirm(sendAndConfirmConfig);
+  }
+
+  getConfig(): {
+    feePayer: string;
+    computeLimit: number;
+    priorityFee: MicroLamports;
+    instructions: Instruction[];
+    isPrepared: boolean;
+  } {
+    return {
+      feePayer: this.feePayer.address,
+      computeLimit: this.computeLimit,
+      priorityFee: this.priorityFee,
+      instructions: this.instructions,
+      isPrepared: this.transactionMessage !== null,
+    };
+  }
+
+  reset(): this {
+    this.instructions = [];
+    this.transactionMessage = null;
+    debug("Transaction builder reset", "debug");
+    return this;
+  }
+
+  getTransactionMessage(): (CompilableTransactionMessage & TransactionMessageWithBlockhashLifetime) | null {
+    return this.transactionMessage;
+  }
+}

--- a/packages/gill/src/core/transaction-builder.ts
+++ b/packages/gill/src/core/transaction-builder.ts
@@ -154,7 +154,7 @@ export class TransactionBuilder {
       computeUnitLimitMultiplier: config?.computeUnitLimitMultiplier ?? DEFAULT_PREPARE_CONFIG.computeUnitLimitMultiplier,
       computeUnitLimitReset: config?.computeUnitLimitReset ?? DEFAULT_PREPARE_CONFIG.computeUnitLimitReset,
       blockhashReset: config?.blockhashReset ?? DEFAULT_PREPARE_CONFIG.blockhashReset,
-    };
+    } as unknown as PrepareTransactionConfig<CompilableTransactionMessage>;
 
     this.transactionMessage = await prepareTransaction(prepareConfig);
     debug("Transaction prepared successfully", "info");


### PR DESCRIPTION
### Problem
Devex of assembling instructions on Kit can be challenging. Gill makes this easier with `createTransaction` and `prepareTransaction`, however some developers prefer a transaction builder structure with reasonable default config.

### Summary of Changes
Adds a lightweight class-based transaction builder for building, preparing, sending, and confirming transactions. 
Additionionally, for comparison/discussion (at the recommendation of @macalinao), I've added a functional transaction builder as well. In practice, we'd only keep one of these--but leaving both in the draft for the sake of discussion.

Example:

```ts
# Class-based
const transferInstruction = getTransferSolInstruction({ /* ... */ });
const signature = await TransactionBuilder.create(client, { feePayer })
    .add(transferInstruction)
    .prepareAndSendAndConfirm();
    
# Functional API (Better Kit Alignment):
const transferInstruction = getTransferSolInstruction({ /* ... */ });
const signature = await createTransactionBuilder({ client, feePayer })
    .add(transferInstruction)
    .prepareAndSendAndConfirm();
```

 1. Class-based implementation (/packages/gill/src/core/transaction-builder.ts):
    - Traditional OOP approach with familiar patterns
 2. Functional implementation (/packages/gill/src/core/create-transaction-builder.ts):
    - Kit-aligned with zero classes
    - Closure-based state management preventing instanceof issues
    - Tree-shakable for optimal bundle size

3. Testing:
    - /packages/gill/src/__tests__/transaction-builder.ts - Class implementation tests
    - /packages/gill/src/__tests__/create-transaction-builder.test.ts - Functional implementation tests
    - /packages/gill/src/__tests__/transaction-builder-comparison.test.ts - Direct comparison tests

Since we don't have integration tests set up in the repo atm, I just did a simple local test of the functional setup: https://gist.github.com/amilz/9bbf917bd4f059bdbbc72b4a1b9772d7