### PR TITLE
refactor: prepare transaction

### DIFF
--- a/.changeset/dry-pants-begin.md
+++ b/.changeset/dry-pants-begin.md
@@ -1,0 +1,5 @@
+---
+"gill": minor
+---
+
+refactor prepare-transaction

--- a/packages/gill/src/__tests__/prepare-transaction.ts
+++ b/packages/gill/src/__tests__/prepare-transaction.ts
@@ -7,7 +7,7 @@ import {
   createNoopSigner,
   type Blockhash,
   type MicroLamports,
-  type Rpc
+  type Rpc,
 } from "@solana/kit";
 import { getTransferSolInstruction, COMPUTE_BUDGET_PROGRAM_ADDRESS } from "../programs";
 import { prepareTransaction } from "../core/prepare-transaction";
@@ -20,15 +20,16 @@ describe("prepareTransaction", () => {
     // Create a transaction without compute budget instructions
     const transaction = pipe(
       createTransactionMessage({ version: 0 }),
-      tx => setTransactionMessageFeePayerSigner(mockFeePayer, tx),
-      tx => appendTransactionMessageInstruction(
-        getTransferSolInstruction({
-          source: mockFeePayer,
-          destination: mockDestination,
-          amount: 1_000_000n,
-        }),
-        tx
-      )
+      (tx) => setTransactionMessageFeePayerSigner(mockFeePayer, tx),
+      (tx) =>
+        appendTransactionMessageInstruction(
+          getTransferSolInstruction({
+            source: mockFeePayer,
+            destination: mockDestination,
+            amount: 1_000_000n,
+          }),
+          tx,
+        ),
     );
 
     // Mock the RPC calls with proper estimateComputeUnitLimitFactory response
@@ -58,9 +59,9 @@ describe("prepareTransaction", () => {
       computeUnitLimitMultiplier: 1.2,
     });
 
-    // Check that compute unit limit instruction was added  
+    // Check that compute unit limit instruction was added
     const hasComputeUnitLimit = prepared.instructions.some(
-      ix => String(ix.programAddress) === String(COMPUTE_BUDGET_PROGRAM_ADDRESS)
+      (ix) => String(ix.programAddress) === String(COMPUTE_BUDGET_PROGRAM_ADDRESS),
     );
     expect(hasComputeUnitLimit).toBe(true);
 
@@ -71,15 +72,16 @@ describe("prepareTransaction", () => {
   it("should add priority fee when provided", async () => {
     const transaction = pipe(
       createTransactionMessage({ version: 0 }),
-      tx => setTransactionMessageFeePayerSigner(mockFeePayer, tx),
-      tx => appendTransactionMessageInstruction(
-        getTransferSolInstruction({
-          source: mockFeePayer,
-          destination: mockDestination,
-          amount: 1_000_000n,
-        }),
-        tx
-      )
+      (tx) => setTransactionMessageFeePayerSigner(mockFeePayer, tx),
+      (tx) =>
+        appendTransactionMessageInstruction(
+          getTransferSolInstruction({
+            source: mockFeePayer,
+            destination: mockDestination,
+            amount: 1_000_000n,
+          }),
+          tx,
+        ),
     );
 
     const mockRpc = {
@@ -110,7 +112,7 @@ describe("prepareTransaction", () => {
 
     // Should have both compute unit limit and price instructions
     const computeBudgetInstructions = prepared.instructions.filter(
-      ix => String(ix.programAddress) === String(COMPUTE_BUDGET_PROGRAM_ADDRESS)
+      (ix) => String(ix.programAddress) === String(COMPUTE_BUDGET_PROGRAM_ADDRESS),
     );
     expect(computeBudgetInstructions.length).toBe(2);
   });
@@ -119,15 +121,16 @@ describe("prepareTransaction", () => {
     // First, create a transaction with a compute unit limit instruction
     let transaction = pipe(
       createTransactionMessage({ version: 0 }),
-      tx => setTransactionMessageFeePayerSigner(mockFeePayer, tx),
-      tx => appendTransactionMessageInstruction(
-        getTransferSolInstruction({
-          source: mockFeePayer,
-          destination: mockDestination,
-          amount: 1_000_000n,
-        }),
-        tx
-      )
+      (tx) => setTransactionMessageFeePayerSigner(mockFeePayer, tx),
+      (tx) =>
+        appendTransactionMessageInstruction(
+          getTransferSolInstruction({
+            source: mockFeePayer,
+            destination: mockDestination,
+            amount: 1_000_000n,
+          }),
+          tx,
+        ),
     );
 
     // Add a compute unit limit instruction first
@@ -169,15 +172,16 @@ describe("prepareTransaction", () => {
   it("should throw when simulation fails", async () => {
     const transaction = pipe(
       createTransactionMessage({ version: 0 }),
-      tx => setTransactionMessageFeePayerSigner(mockFeePayer, tx),
-      tx => appendTransactionMessageInstruction(
-        getTransferSolInstruction({
-          source: mockFeePayer,
-          destination: mockDestination,
-          amount: 1_000_000n,
-        }),
-        tx
-      )
+      (tx) => setTransactionMessageFeePayerSigner(mockFeePayer, tx),
+      (tx) =>
+        appendTransactionMessageInstruction(
+          getTransferSolInstruction({
+            source: mockFeePayer,
+            destination: mockDestination,
+            amount: 1_000_000n,
+          }),
+          tx,
+        ),
     );
 
     // Mock RPC that will cause the estimateComputeUnitLimitFactory to throw
@@ -197,25 +201,28 @@ describe("prepareTransaction", () => {
       }),
     } as Rpc<any>;
 
-    await expect(prepareTransaction({
-      transaction,
-      rpc: mockRpc,
-    })).rejects.toThrow();
+    await expect(
+      prepareTransaction({
+        transaction,
+        rpc: mockRpc,
+      }),
+    ).rejects.toThrow();
   });
 
   // Compute unit edge cases
   it("should cap compute units at MAX_COMPUTE_UNIT_LIMIT when estimation exceeds it", async () => {
     const transaction = pipe(
       createTransactionMessage({ version: 0 }),
-      tx => setTransactionMessageFeePayerSigner(mockFeePayer, tx),
-      tx => appendTransactionMessageInstruction(
-        getTransferSolInstruction({
-          source: mockFeePayer,
-          destination: mockDestination,
-          amount: 1_000_000n,
-        }),
-        tx
-      )
+      (tx) => setTransactionMessageFeePayerSigner(mockFeePayer, tx),
+      (tx) =>
+        appendTransactionMessageInstruction(
+          getTransferSolInstruction({
+            source: mockFeePayer,
+            destination: mockDestination,
+            amount: 1_000_000n,
+          }),
+          tx,
+        ),
     );
 
     const mockRpc = {
@@ -246,8 +253,7 @@ describe("prepareTransaction", () => {
 
     // Find the compute unit limit instruction
     const computeLimitInstruction = prepared.instructions.find(
-      ix => String(ix.programAddress) === String(COMPUTE_BUDGET_PROGRAM_ADDRESS) &&
-        ix.data && ix.data[0] === 2 // SetComputeUnitLimit instruction discriminator
+      (ix) => String(ix.programAddress) === String(COMPUTE_BUDGET_PROGRAM_ADDRESS) && ix.data && ix.data[0] === 2, // SetComputeUnitLimit instruction discriminator
     );
 
     expect(computeLimitInstruction).toBeDefined();
@@ -265,15 +271,16 @@ describe("prepareTransaction", () => {
   it("should accept computeUnitPrice as number", async () => {
     const transaction = pipe(
       createTransactionMessage({ version: 0 }),
-      tx => setTransactionMessageFeePayerSigner(mockFeePayer, tx),
-      tx => appendTransactionMessageInstruction(
-        getTransferSolInstruction({
-          source: mockFeePayer,
-          destination: mockDestination,
-          amount: 1_000_000n,
-        }),
-        tx
-      )
+      (tx) => setTransactionMessageFeePayerSigner(mockFeePayer, tx),
+      (tx) =>
+        appendTransactionMessageInstruction(
+          getTransferSolInstruction({
+            source: mockFeePayer,
+            destination: mockDestination,
+            amount: 1_000_000n,
+          }),
+          tx,
+        ),
     );
 
     const mockRpc = {
@@ -304,28 +311,29 @@ describe("prepareTransaction", () => {
 
     // Should have both compute limit and price instructions
     const computeBudgetInstructions = prepared.instructions.filter(
-      ix => String(ix.programAddress) === String(COMPUTE_BUDGET_PROGRAM_ADDRESS)
+      (ix) => String(ix.programAddress) === String(COMPUTE_BUDGET_PROGRAM_ADDRESS),
     );
     expect(computeBudgetInstructions.length).toBe(2);
 
     // Find the price instruction
     const priceInstruction = computeBudgetInstructions.find(
-      ix => ix.data && ix.data[0] === 3 // SetComputeUnitPrice instruction discriminator
+      (ix) => ix.data && ix.data[0] === 3, // SetComputeUnitPrice instruction discriminator
     );
     expect(priceInstruction).toBeDefined();
   });
   it("should accept computeUnitPrice as bigint", async () => {
     const transaction = pipe(
       createTransactionMessage({ version: 0 }),
-      tx => setTransactionMessageFeePayerSigner(mockFeePayer, tx),
-      tx => appendTransactionMessageInstruction(
-        getTransferSolInstruction({
-          source: mockFeePayer,
-          destination: mockDestination,
-          amount: 1_000_000n,
-        }),
-        tx
-      )
+      (tx) => setTransactionMessageFeePayerSigner(mockFeePayer, tx),
+      (tx) =>
+        appendTransactionMessageInstruction(
+          getTransferSolInstruction({
+            source: mockFeePayer,
+            destination: mockDestination,
+            amount: 1_000_000n,
+          }),
+          tx,
+        ),
     );
 
     const mockRpc = {
@@ -356,23 +364,23 @@ describe("prepareTransaction", () => {
 
     // Should have both compute limit and price instructions
     const computeBudgetInstructions = prepared.instructions.filter(
-      ix => String(ix.programAddress) === String(COMPUTE_BUDGET_PROGRAM_ADDRESS)
+      (ix) => String(ix.programAddress) === String(COMPUTE_BUDGET_PROGRAM_ADDRESS),
     );
     expect(computeBudgetInstructions.length).toBe(2);
   });
   it("should accept computeUnitPrice as MicroLamports", async () => {
-
     const transaction = pipe(
       createTransactionMessage({ version: 0 }),
-      tx => setTransactionMessageFeePayerSigner(mockFeePayer, tx),
-      tx => appendTransactionMessageInstruction(
-        getTransferSolInstruction({
-          source: mockFeePayer,
-          destination: mockDestination,
-          amount: 1_000_000n,
-        }),
-        tx
-      )
+      (tx) => setTransactionMessageFeePayerSigner(mockFeePayer, tx),
+      (tx) =>
+        appendTransactionMessageInstruction(
+          getTransferSolInstruction({
+            source: mockFeePayer,
+            destination: mockDestination,
+            amount: 1_000_000n,
+          }),
+          tx,
+        ),
     );
 
     const mockRpc = {
@@ -403,7 +411,7 @@ describe("prepareTransaction", () => {
 
     // Should have both compute limit and price instructions
     const computeBudgetInstructions = prepared.instructions.filter(
-      ix => String(ix.programAddress) === String(COMPUTE_BUDGET_PROGRAM_ADDRESS)
+      (ix) => String(ix.programAddress) === String(COMPUTE_BUDGET_PROGRAM_ADDRESS),
     );
     expect(computeBudgetInstructions.length).toBe(2);
   });
@@ -414,22 +422,23 @@ describe("prepareTransaction", () => {
 
     const transaction = pipe(
       createTransactionMessage({ version: 0 }),
-      tx => setTransactionMessageFeePayerSigner(mockFeePayer, tx),
-      tx => ({
+      (tx) => setTransactionMessageFeePayerSigner(mockFeePayer, tx),
+      (tx) => ({
         ...tx,
         lifetimeConstraint: {
           blockhash: existingBlockhash as Blockhash,
           lastValidBlockHeight: 50n,
         },
       }),
-      tx => appendTransactionMessageInstruction(
-        getTransferSolInstruction({
-          source: mockFeePayer,
-          destination: mockDestination,
-          amount: 1_000_000n,
-        }),
-        tx
-      )
+      (tx) =>
+        appendTransactionMessageInstruction(
+          getTransferSolInstruction({
+            source: mockFeePayer,
+            destination: mockDestination,
+            amount: 1_000_000n,
+          }),
+          tx,
+        ),
     );
 
     const mockRpc = {
@@ -468,22 +477,23 @@ describe("prepareTransaction", () => {
 
     const transaction = pipe(
       createTransactionMessage({ version: 0 }),
-      tx => setTransactionMessageFeePayerSigner(mockFeePayer, tx),
-      tx => ({
+      (tx) => setTransactionMessageFeePayerSigner(mockFeePayer, tx),
+      (tx) => ({
         ...tx,
         lifetimeConstraint: {
           blockhash: existingBlockhash as Blockhash,
           lastValidBlockHeight: 50n,
         },
       }),
-      tx => appendTransactionMessageInstruction(
-        getTransferSolInstruction({
-          source: mockFeePayer,
-          destination: mockDestination,
-          amount: 1_000_000n,
-        }),
-        tx
-      )
+      (tx) =>
+        appendTransactionMessageInstruction(
+          getTransferSolInstruction({
+            source: mockFeePayer,
+            destination: mockDestination,
+            amount: 1_000_000n,
+          }),
+          tx,
+        ),
     );
 
     const mockRpc = {
@@ -520,15 +530,16 @@ describe("prepareTransaction", () => {
     // Create transaction without blockhash
     const transaction = pipe(
       createTransactionMessage({ version: 0 }),
-      tx => setTransactionMessageFeePayerSigner(mockFeePayer, tx),
-      tx => appendTransactionMessageInstruction(
-        getTransferSolInstruction({
-          source: mockFeePayer,
-          destination: mockDestination,
-          amount: 1_000_000n,
-        }),
-        tx
-      )
+      (tx) => setTransactionMessageFeePayerSigner(mockFeePayer, tx),
+      (tx) =>
+        appendTransactionMessageInstruction(
+          getTransferSolInstruction({
+            source: mockFeePayer,
+            destination: mockDestination,
+            amount: 1_000_000n,
+          }),
+          tx,
+        ),
     );
 
     const newBlockhash = "5eykt4UsFv8P8NJdTREpY1vzqKqZKvdpKuc147dw2N9d";
@@ -571,22 +582,23 @@ describe("prepareTransaction", () => {
 
     const transaction = pipe(
       createTransactionMessage({ version: 0 }),
-      tx => setTransactionMessageFeePayerSigner(mockFeePayer, tx),
-      tx => ({
+      (tx) => setTransactionMessageFeePayerSigner(mockFeePayer, tx),
+      (tx) => ({
         ...tx,
         lifetimeConstraint: {
           blockhash: existingBlockhash as Blockhash,
           lastValidBlockHeight: 50n,
         },
       }),
-      tx => appendTransactionMessageInstruction(
-        getTransferSolInstruction({
-          source: mockFeePayer,
-          destination: mockDestination,
-          amount: 1_000_000n,
-        }),
-        tx
-      )
+      (tx) =>
+        appendTransactionMessageInstruction(
+          getTransferSolInstruction({
+            source: mockFeePayer,
+            destination: mockDestination,
+            amount: 1_000_000n,
+          }),
+          tx,
+        ),
     );
 
     const mockRpc = {
@@ -622,8 +634,7 @@ describe("prepareTransaction", () => {
 
     // Should have compute unit limit instruction added
     const hasComputeUnitLimit = prepared.instructions.some(
-      ix => String(ix.programAddress) === String(COMPUTE_BUDGET_PROGRAM_ADDRESS) &&
-        ix.data && ix.data[0] === 2 // SetComputeUnitLimit instruction discriminator
+      (ix) => String(ix.programAddress) === String(COMPUTE_BUDGET_PROGRAM_ADDRESS) && ix.data && ix.data[0] === 2, // SetComputeUnitLimit instruction discriminator
     );
     expect(hasComputeUnitLimit).toBe(true);
   });
@@ -635,23 +646,24 @@ describe("prepareTransaction", () => {
 
     const transaction = pipe(
       createTransactionMessage({ version: 0 }),
-      tx => setTransactionMessageFeePayerSigner(mockFeePayer, tx),
-      tx => ({
+      (tx) => setTransactionMessageFeePayerSigner(mockFeePayer, tx),
+      (tx) => ({
         ...tx,
         lifetimeConstraint: {
           blockhash: existingBlockhash as Blockhash,
           lastValidBlockHeight: 50n,
         },
       }),
-      tx => updateOrAppendSetComputeUnitLimitInstruction(100_000, tx), // Pre-add compute limit
-      tx => appendTransactionMessageInstruction(
-        getTransferSolInstruction({
-          source: mockFeePayer,
-          destination: mockDestination,
-          amount: 1_000_000n,
-        }),
-        tx
-      )
+      (tx) => updateOrAppendSetComputeUnitLimitInstruction(100_000, tx), // Pre-add compute limit
+      (tx) =>
+        appendTransactionMessageInstruction(
+          getTransferSolInstruction({
+            source: mockFeePayer,
+            destination: mockDestination,
+            amount: 1_000_000n,
+          }),
+          tx,
+        ),
     );
 
     const mockRpc = {
@@ -687,8 +699,7 @@ describe("prepareTransaction", () => {
 
     // Should have kept the existing compute unit limit instruction (no re-estimation)
     const computeLimitInstructions = prepared.instructions.filter(
-      ix => String(ix.programAddress) === String(COMPUTE_BUDGET_PROGRAM_ADDRESS) &&
-        ix.data && ix.data[0] === 2 // SetComputeUnitLimit instruction discriminator
+      (ix) => String(ix.programAddress) === String(COMPUTE_BUDGET_PROGRAM_ADDRESS) && ix.data && ix.data[0] === 2, // SetComputeUnitLimit instruction discriminator
     );
     expect(computeLimitInstructions.length).toBe(1);
   });
@@ -699,23 +710,24 @@ describe("prepareTransaction", () => {
 
     const transaction = pipe(
       createTransactionMessage({ version: 0 }),
-      tx => setTransactionMessageFeePayerSigner(mockFeePayer, tx),
-      tx => ({
+      (tx) => setTransactionMessageFeePayerSigner(mockFeePayer, tx),
+      (tx) => ({
         ...tx,
         lifetimeConstraint: {
           blockhash: existingBlockhash as Blockhash,
           lastValidBlockHeight: 50n,
         },
       }),
-      tx => updateOrAppendSetComputeUnitLimitInstruction(100_000, tx), // Pre-add compute limit
-      tx => appendTransactionMessageInstruction(
-        getTransferSolInstruction({
-          source: mockFeePayer,
-          destination: mockDestination,
-          amount: 1_000_000n,
-        }),
-        tx
-      )
+      (tx) => updateOrAppendSetComputeUnitLimitInstruction(100_000, tx), // Pre-add compute limit
+      (tx) =>
+        appendTransactionMessageInstruction(
+          getTransferSolInstruction({
+            source: mockFeePayer,
+            destination: mockDestination,
+            amount: 1_000_000n,
+          }),
+          tx,
+        ),
     );
 
     const mockRpc = {
@@ -751,29 +763,31 @@ describe("prepareTransaction", () => {
 
     // Should have kept the existing compute unit limit instruction unchanged
     const computeLimitInstructions = prepared.instructions.filter(
-      ix => String(ix.programAddress) === String(COMPUTE_BUDGET_PROGRAM_ADDRESS) &&
-        ix.data && ix.data[0] === 2 // SetComputeUnitLimit instruction discriminator
+      (ix) => String(ix.programAddress) === String(COMPUTE_BUDGET_PROGRAM_ADDRESS) && ix.data && ix.data[0] === 2, // SetComputeUnitLimit instruction discriminator
     );
     expect(computeLimitInstructions.length).toBe(1);
   });
 
   // Complex scenarios
   it("should handle transactions that already have both compute limit and price instructions", async () => {
-    const { updateOrAppendSetComputeUnitLimitInstruction, updateOrAppendSetComputeUnitPriceInstruction } = await import("@solana-program/compute-budget");
+    const { updateOrAppendSetComputeUnitLimitInstruction, updateOrAppendSetComputeUnitPriceInstruction } = await import(
+      "@solana-program/compute-budget"
+    );
 
     const transaction = pipe(
       createTransactionMessage({ version: 0 }),
-      tx => setTransactionMessageFeePayerSigner(mockFeePayer, tx),
-      tx => updateOrAppendSetComputeUnitLimitInstruction(80_000, tx), // Pre-add compute limit
-      tx => updateOrAppendSetComputeUnitPriceInstruction(1000n as MicroLamports, tx), // Pre-add priority fee
-      tx => appendTransactionMessageInstruction(
-        getTransferSolInstruction({
-          source: mockFeePayer,
-          destination: mockDestination,
-          amount: 1_000_000n,
-        }),
-        tx
-      )
+      (tx) => setTransactionMessageFeePayerSigner(mockFeePayer, tx),
+      (tx) => updateOrAppendSetComputeUnitLimitInstruction(80_000, tx), // Pre-add compute limit
+      (tx) => updateOrAppendSetComputeUnitPriceInstruction(1000n as MicroLamports, tx), // Pre-add priority fee
+      (tx) =>
+        appendTransactionMessageInstruction(
+          getTransferSolInstruction({
+            source: mockFeePayer,
+            destination: mockDestination,
+            amount: 1_000_000n,
+          }),
+          tx,
+        ),
     );
 
     const mockRpc = {
@@ -805,19 +819,19 @@ describe("prepareTransaction", () => {
 
     // Should still have both compute limit and price instructions
     const computeBudgetInstructions = prepared.instructions.filter(
-      ix => String(ix.programAddress) === String(COMPUTE_BUDGET_PROGRAM_ADDRESS)
+      (ix) => String(ix.programAddress) === String(COMPUTE_BUDGET_PROGRAM_ADDRESS),
     );
     expect(computeBudgetInstructions.length).toBe(2);
 
     // Should have updated limit through re-estimation (5000 * 1.1 = 5500)
     const computeLimitInstruction = computeBudgetInstructions.find(
-      ix => ix.data && ix.data[0] === 2 // SetComputeUnitLimit instruction discriminator
+      (ix) => ix.data && ix.data[0] === 2, // SetComputeUnitLimit instruction discriminator
     );
     expect(computeLimitInstruction).toBeDefined();
 
     // Should have updated price instruction
     const computePriceInstruction = computeBudgetInstructions.find(
-      ix => ix.data && ix.data[0] === 3 // SetComputeUnitPrice instruction discriminator
+      (ix) => ix.data && ix.data[0] === 3, // SetComputeUnitPrice instruction discriminator
     );
     expect(computePriceInstruction).toBeDefined();
   });
@@ -826,15 +840,16 @@ describe("prepareTransaction", () => {
   it("should use default computeUnitLimitMultiplier of 1.1 when not specified", async () => {
     const transaction = pipe(
       createTransactionMessage({ version: 0 }),
-      tx => setTransactionMessageFeePayerSigner(mockFeePayer, tx),
-      tx => appendTransactionMessageInstruction(
-        getTransferSolInstruction({
-          source: mockFeePayer,
-          destination: mockDestination,
-          amount: 1_000_000n,
-        }),
-        tx
-      )
+      (tx) => setTransactionMessageFeePayerSigner(mockFeePayer, tx),
+      (tx) =>
+        appendTransactionMessageInstruction(
+          getTransferSolInstruction({
+            source: mockFeePayer,
+            destination: mockDestination,
+            amount: 1_000_000n,
+          }),
+          tx,
+        ),
     );
 
     const mockRpc = {
@@ -865,8 +880,7 @@ describe("prepareTransaction", () => {
 
     // Find the compute unit limit instruction and verify it used the 1.1 multiplier
     const computeLimitInstruction = prepared.instructions.find(
-      ix => String(ix.programAddress) === String(COMPUTE_BUDGET_PROGRAM_ADDRESS) &&
-        ix.data && ix.data[0] === 2 // SetComputeUnitLimit instruction discriminator
+      (ix) => String(ix.programAddress) === String(COMPUTE_BUDGET_PROGRAM_ADDRESS) && ix.data && ix.data[0] === 2, // SetComputeUnitLimit instruction discriminator
     );
 
     expect(computeLimitInstruction).toBeDefined();
@@ -877,5 +891,4 @@ describe("prepareTransaction", () => {
       expect(units).toBe(11000); // 10000 * 1.1 = 11000
     }
   });
-
 });

--- a/packages/gill/src/__tests__/prepare-transaction.ts
+++ b/packages/gill/src/__tests__/prepare-transaction.ts
@@ -1,0 +1,881 @@
+import {
+  address,
+  createTransactionMessage,
+  pipe,
+  setTransactionMessageFeePayerSigner,
+  appendTransactionMessageInstruction,
+  createNoopSigner,
+  type Blockhash,
+  type MicroLamports,
+  type Rpc
+} from "@solana/kit";
+import { getTransferSolInstruction, COMPUTE_BUDGET_PROGRAM_ADDRESS } from "../programs";
+import { prepareTransaction } from "../core/prepare-transaction";
+
+describe("prepareTransaction", () => {
+  const mockFeePayer = createNoopSigner(address("AMi1Z111111111111111111111111111111111111111"));
+  const mockDestination = address("Gi11222222222222222222222222222222222222222");
+
+  it("should add compute unit limit when none exists", async () => {
+    // Create a transaction without compute budget instructions
+    const transaction = pipe(
+      createTransactionMessage({ version: 0 }),
+      tx => setTransactionMessageFeePayerSigner(mockFeePayer, tx),
+      tx => appendTransactionMessageInstruction(
+        getTransferSolInstruction({
+          source: mockFeePayer,
+          destination: mockDestination,
+          amount: 1_000_000n,
+        }),
+        tx
+      )
+    );
+
+    // Mock the RPC calls with proper estimateComputeUnitLimitFactory response
+    const mockRpc = {
+      getLatestBlockhash: () => ({
+        send: async () => ({
+          value: {
+            blockhash: "GHtXQBsoZHVnNFa9YevAzFr17DJjgHXk3ycTKD5xD3Zi" as Blockhash,
+            lastValidBlockHeight: 100n,
+          },
+        }),
+      }),
+      simulateTransaction: () => ({
+        send: async () => ({
+          value: {
+            err: null,
+            unitsConsumed: 5000n,
+            logs: [],
+          },
+        }),
+      }),
+    } as Rpc<any>;
+
+    const prepared = await prepareTransaction({
+      transaction,
+      rpc: mockRpc,
+      computeUnitLimitMultiplier: 1.2,
+    });
+
+    // Check that compute unit limit instruction was added  
+    const hasComputeUnitLimit = prepared.instructions.some(
+      ix => String(ix.programAddress) === String(COMPUTE_BUDGET_PROGRAM_ADDRESS)
+    );
+    expect(hasComputeUnitLimit).toBe(true);
+
+    // Check that blockhash was set
+    expect(prepared.lifetimeConstraint.blockhash).toBe("GHtXQBsoZHVnNFa9YevAzFr17DJjgHXk3ycTKD5xD3Zi");
+  });
+
+  it("should add priority fee when provided", async () => {
+    const transaction = pipe(
+      createTransactionMessage({ version: 0 }),
+      tx => setTransactionMessageFeePayerSigner(mockFeePayer, tx),
+      tx => appendTransactionMessageInstruction(
+        getTransferSolInstruction({
+          source: mockFeePayer,
+          destination: mockDestination,
+          amount: 1_000_000n,
+        }),
+        tx
+      )
+    );
+
+    const mockRpc = {
+      getLatestBlockhash: () => ({
+        send: async () => ({
+          value: {
+            blockhash: "GHtXQBsoZHVnNFa9YevAzFr17DJjgHXk3ycTKD5xD3Zi" as Blockhash,
+            lastValidBlockHeight: 100n,
+          },
+        }),
+      }),
+      simulateTransaction: () => ({
+        send: async () => ({
+          value: {
+            err: null,
+            unitsConsumed: 5000n,
+            logs: [],
+          },
+        }),
+      }),
+    } as Rpc<any>;
+
+    const prepared = await prepareTransaction({
+      transaction,
+      rpc: mockRpc,
+      computeUnitPrice: 5000n, // 5000 microlamports
+    });
+
+    // Should have both compute unit limit and price instructions
+    const computeBudgetInstructions = prepared.instructions.filter(
+      ix => String(ix.programAddress) === String(COMPUTE_BUDGET_PROGRAM_ADDRESS)
+    );
+    expect(computeBudgetInstructions.length).toBe(2);
+  });
+
+  it("should not re-estimate when computeUnitLimitReset is false and limit exists", async () => {
+    // First, create a transaction with a compute unit limit instruction
+    let transaction = pipe(
+      createTransactionMessage({ version: 0 }),
+      tx => setTransactionMessageFeePayerSigner(mockFeePayer, tx),
+      tx => appendTransactionMessageInstruction(
+        getTransferSolInstruction({
+          source: mockFeePayer,
+          destination: mockDestination,
+          amount: 1_000_000n,
+        }),
+        tx
+      )
+    );
+
+    // Add a compute unit limit instruction first
+    const { updateOrAppendSetComputeUnitLimitInstruction } = await import("@solana-program/compute-budget");
+    transaction = updateOrAppendSetComputeUnitLimitInstruction(100_000, transaction);
+
+    // Create a mock that tracks if estimation is called
+    let estimationCalled = false;
+    const mockRpc = {
+      getLatestBlockhash: () => ({
+        send: async () => ({
+          value: {
+            blockhash: "GHtXQBsoZHVnNFa9YevAzFr17DJjgHXk3ycTKD5xD3Zi" as Blockhash,
+            lastValidBlockHeight: 100n,
+          },
+        }),
+      }),
+    } as Rpc<any>;
+
+    // Mock the estimation factory to track if it's called
+    jest.mock("@solana-program/compute-budget", () => ({
+      ...jest.requireActual("@solana-program/compute-budget"),
+      estimateComputeUnitLimitFactory: () => () => {
+        estimationCalled = true;
+        return Promise.resolve(5000);
+      },
+    }));
+
+    await prepareTransaction({
+      transaction,
+      rpc: mockRpc,
+      computeUnitLimitReset: false,
+    });
+
+    // Since computeUnitLimitReset is false and we already have a limit, estimation should not be called
+    expect(estimationCalled).toBe(false);
+  });
+
+  it("should throw when simulation fails", async () => {
+    const transaction = pipe(
+      createTransactionMessage({ version: 0 }),
+      tx => setTransactionMessageFeePayerSigner(mockFeePayer, tx),
+      tx => appendTransactionMessageInstruction(
+        getTransferSolInstruction({
+          source: mockFeePayer,
+          destination: mockDestination,
+          amount: 1_000_000n,
+        }),
+        tx
+      )
+    );
+
+    // Mock RPC that will cause the estimateComputeUnitLimitFactory to throw
+    const mockRpc = {
+      getLatestBlockhash: () => ({
+        send: async () => ({
+          value: {
+            blockhash: "GHtXQBsoZHVnNFa9YevAzFr17DJjgHXk3ycTKD5xD3Zi" as Blockhash,
+            lastValidBlockHeight: 100n,
+          },
+        }),
+      }),
+      simulateTransaction: () => ({
+        send: async () => {
+          throw new Error("RPC simulation failed");
+        },
+      }),
+    } as Rpc<any>;
+
+    await expect(prepareTransaction({
+      transaction,
+      rpc: mockRpc,
+    })).rejects.toThrow();
+  });
+
+  // Compute unit edge cases
+  it("should cap compute units at MAX_COMPUTE_UNIT_LIMIT when estimation exceeds it", async () => {
+    const transaction = pipe(
+      createTransactionMessage({ version: 0 }),
+      tx => setTransactionMessageFeePayerSigner(mockFeePayer, tx),
+      tx => appendTransactionMessageInstruction(
+        getTransferSolInstruction({
+          source: mockFeePayer,
+          destination: mockDestination,
+          amount: 1_000_000n,
+        }),
+        tx
+      )
+    );
+
+    const mockRpc = {
+      getLatestBlockhash: () => ({
+        send: async () => ({
+          value: {
+            blockhash: "GHtXQBsoZHVnNFa9YevAzFr17DJjgHXk3ycTKD5xD3Zi" as Blockhash,
+            lastValidBlockHeight: 100n,
+          },
+        }),
+      }),
+      simulateTransaction: () => ({
+        send: async () => ({
+          value: {
+            err: null,
+            unitsConsumed: 1_300_000n, // Very high consumption that will exceed max when multiplied
+            logs: [],
+          },
+        }),
+      }),
+    } as Rpc<any>;
+
+    const prepared = await prepareTransaction({
+      transaction,
+      rpc: mockRpc,
+      computeUnitLimitMultiplier: 1.5, // This would result in 1.95M, which exceeds the max
+    });
+
+    // Find the compute unit limit instruction
+    const computeLimitInstruction = prepared.instructions.find(
+      ix => String(ix.programAddress) === String(COMPUTE_BUDGET_PROGRAM_ADDRESS) &&
+        ix.data && ix.data[0] === 2 // SetComputeUnitLimit instruction discriminator
+    );
+
+    expect(computeLimitInstruction).toBeDefined();
+    // The compute limit should be capped at MAX_COMPUTE_UNIT_LIMIT (1.4M)
+    // We can verify this by checking the instruction data
+    if (computeLimitInstruction?.data) {
+      // Extract units from instruction data (bytes 1-4 in little-endian format)
+      const unitsBytes = computeLimitInstruction.data.slice(1, 5);
+      const units = new DataView(unitsBytes.buffer).getUint32(0, true);
+      expect(units).toBe(1_400_000); // MAX_COMPUTE_UNIT_LIMIT
+    }
+  });
+
+  // Priority fee scenarios
+  it("should accept computeUnitPrice as number", async () => {
+    const transaction = pipe(
+      createTransactionMessage({ version: 0 }),
+      tx => setTransactionMessageFeePayerSigner(mockFeePayer, tx),
+      tx => appendTransactionMessageInstruction(
+        getTransferSolInstruction({
+          source: mockFeePayer,
+          destination: mockDestination,
+          amount: 1_000_000n,
+        }),
+        tx
+      )
+    );
+
+    const mockRpc = {
+      getLatestBlockhash: () => ({
+        send: async () => ({
+          value: {
+            blockhash: "GHtXQBsoZHVnNFa9YevAzFr17DJjgHXk3ycTKD5xD3Zi" as Blockhash,
+            lastValidBlockHeight: 100n,
+          },
+        }),
+      }),
+      simulateTransaction: () => ({
+        send: async () => ({
+          value: {
+            err: null,
+            unitsConsumed: 5000n,
+            logs: [],
+          },
+        }),
+      }),
+    } as Rpc<any>;
+
+    const prepared = await prepareTransaction({
+      transaction,
+      rpc: mockRpc,
+      computeUnitPrice: 1000, // number
+    });
+
+    // Should have both compute limit and price instructions
+    const computeBudgetInstructions = prepared.instructions.filter(
+      ix => String(ix.programAddress) === String(COMPUTE_BUDGET_PROGRAM_ADDRESS)
+    );
+    expect(computeBudgetInstructions.length).toBe(2);
+
+    // Find the price instruction
+    const priceInstruction = computeBudgetInstructions.find(
+      ix => ix.data && ix.data[0] === 3 // SetComputeUnitPrice instruction discriminator
+    );
+    expect(priceInstruction).toBeDefined();
+  });
+  it("should accept computeUnitPrice as bigint", async () => {
+    const transaction = pipe(
+      createTransactionMessage({ version: 0 }),
+      tx => setTransactionMessageFeePayerSigner(mockFeePayer, tx),
+      tx => appendTransactionMessageInstruction(
+        getTransferSolInstruction({
+          source: mockFeePayer,
+          destination: mockDestination,
+          amount: 1_000_000n,
+        }),
+        tx
+      )
+    );
+
+    const mockRpc = {
+      getLatestBlockhash: () => ({
+        send: async () => ({
+          value: {
+            blockhash: "GHtXQBsoZHVnNFa9YevAzFr17DJjgHXk3ycTKD5xD3Zi" as Blockhash,
+            lastValidBlockHeight: 100n,
+          },
+        }),
+      }),
+      simulateTransaction: () => ({
+        send: async () => ({
+          value: {
+            err: null,
+            unitsConsumed: 5000n,
+            logs: [],
+          },
+        }),
+      }),
+    } as Rpc<any>;
+
+    const prepared = await prepareTransaction({
+      transaction,
+      rpc: mockRpc,
+      computeUnitPrice: 2000n, // bigint
+    });
+
+    // Should have both compute limit and price instructions
+    const computeBudgetInstructions = prepared.instructions.filter(
+      ix => String(ix.programAddress) === String(COMPUTE_BUDGET_PROGRAM_ADDRESS)
+    );
+    expect(computeBudgetInstructions.length).toBe(2);
+  });
+  it("should accept computeUnitPrice as MicroLamports", async () => {
+
+    const transaction = pipe(
+      createTransactionMessage({ version: 0 }),
+      tx => setTransactionMessageFeePayerSigner(mockFeePayer, tx),
+      tx => appendTransactionMessageInstruction(
+        getTransferSolInstruction({
+          source: mockFeePayer,
+          destination: mockDestination,
+          amount: 1_000_000n,
+        }),
+        tx
+      )
+    );
+
+    const mockRpc = {
+      getLatestBlockhash: () => ({
+        send: async () => ({
+          value: {
+            blockhash: "GHtXQBsoZHVnNFa9YevAzFr17DJjgHXk3ycTKD5xD3Zi" as Blockhash,
+            lastValidBlockHeight: 100n,
+          },
+        }),
+      }),
+      simulateTransaction: () => ({
+        send: async () => ({
+          value: {
+            err: null,
+            unitsConsumed: 5000n,
+            logs: [],
+          },
+        }),
+      }),
+    } as Rpc<any>;
+
+    const prepared = await prepareTransaction({
+      transaction,
+      rpc: mockRpc,
+      computeUnitPrice: 3000n as MicroLamports,
+    });
+
+    // Should have both compute limit and price instructions
+    const computeBudgetInstructions = prepared.instructions.filter(
+      ix => String(ix.programAddress) === String(COMPUTE_BUDGET_PROGRAM_ADDRESS)
+    );
+    expect(computeBudgetInstructions.length).toBe(2);
+  });
+
+  // Blockhash scenarios
+  it("should preserve existing blockhash when blockhashReset is false", async () => {
+    const existingBlockhash = "9WzDXwBbmkg8ZTbNMqUxvQRAyrZzDsGYdLVL9zYtAWWM";
+
+    const transaction = pipe(
+      createTransactionMessage({ version: 0 }),
+      tx => setTransactionMessageFeePayerSigner(mockFeePayer, tx),
+      tx => ({
+        ...tx,
+        lifetimeConstraint: {
+          blockhash: existingBlockhash as Blockhash,
+          lastValidBlockHeight: 50n,
+        },
+      }),
+      tx => appendTransactionMessageInstruction(
+        getTransferSolInstruction({
+          source: mockFeePayer,
+          destination: mockDestination,
+          amount: 1_000_000n,
+        }),
+        tx
+      )
+    );
+
+    const mockRpc = {
+      getLatestBlockhash: () => ({
+        send: async () => ({
+          value: {
+            blockhash: "5eykt4UsFv8P8NJdTREpY1vzqKqZKvdpKuc147dw2N9d" as Blockhash,
+            lastValidBlockHeight: 100n,
+          },
+        }),
+      }),
+      simulateTransaction: () => ({
+        send: async () => ({
+          value: {
+            err: null,
+            unitsConsumed: 5000n,
+            logs: [],
+          },
+        }),
+      }),
+    } as Rpc<any>;
+
+    const prepared = await prepareTransaction({
+      transaction,
+      rpc: mockRpc,
+      blockhashReset: false,
+    });
+
+    // Should preserve the original blockhash
+    expect(prepared.lifetimeConstraint.blockhash).toBe(existingBlockhash);
+    expect(prepared.lifetimeConstraint.lastValidBlockHeight).toBe(50n);
+  });
+  it("should update existing blockhash when blockhashReset is true", async () => {
+    const existingBlockhash = "9WzDXwBbmkg8ZTbNMqUxvQRAyrZzDsGYdLVL9zYtAWWM";
+    const newBlockhash = "5eykt4UsFv8P8NJdTREpY1vzqKqZKvdpKuc147dw2N9d";
+
+    const transaction = pipe(
+      createTransactionMessage({ version: 0 }),
+      tx => setTransactionMessageFeePayerSigner(mockFeePayer, tx),
+      tx => ({
+        ...tx,
+        lifetimeConstraint: {
+          blockhash: existingBlockhash as Blockhash,
+          lastValidBlockHeight: 50n,
+        },
+      }),
+      tx => appendTransactionMessageInstruction(
+        getTransferSolInstruction({
+          source: mockFeePayer,
+          destination: mockDestination,
+          amount: 1_000_000n,
+        }),
+        tx
+      )
+    );
+
+    const mockRpc = {
+      getLatestBlockhash: () => ({
+        send: async () => ({
+          value: {
+            blockhash: newBlockhash as Blockhash,
+            lastValidBlockHeight: 100n,
+          },
+        }),
+      }),
+      simulateTransaction: () => ({
+        send: async () => ({
+          value: {
+            err: null,
+            unitsConsumed: 5000n,
+            logs: [],
+          },
+        }),
+      }),
+    } as Rpc<any>;
+
+    const prepared = await prepareTransaction({
+      transaction,
+      rpc: mockRpc,
+      blockhashReset: true,
+    });
+
+    // Should use the new blockhash
+    expect(prepared.lifetimeConstraint.blockhash).toBe(newBlockhash);
+    expect(prepared.lifetimeConstraint.lastValidBlockHeight).toBe(100n);
+  });
+  it("should add blockhash when transaction has none and blockhashReset is false", async () => {
+    // Create transaction without blockhash
+    const transaction = pipe(
+      createTransactionMessage({ version: 0 }),
+      tx => setTransactionMessageFeePayerSigner(mockFeePayer, tx),
+      tx => appendTransactionMessageInstruction(
+        getTransferSolInstruction({
+          source: mockFeePayer,
+          destination: mockDestination,
+          amount: 1_000_000n,
+        }),
+        tx
+      )
+    );
+
+    const newBlockhash = "5eykt4UsFv8P8NJdTREpY1vzqKqZKvdpKuc147dw2N9d";
+
+    const mockRpc = {
+      getLatestBlockhash: () => ({
+        send: async () => ({
+          value: {
+            blockhash: newBlockhash as Blockhash,
+            lastValidBlockHeight: 100n,
+          },
+        }),
+      }),
+      simulateTransaction: () => ({
+        send: async () => ({
+          value: {
+            err: null,
+            unitsConsumed: 5000n,
+            logs: [],
+          },
+        }),
+      }),
+    } as Rpc<any>;
+
+    const prepared = await prepareTransaction({
+      transaction,
+      rpc: mockRpc,
+      blockhashReset: false, // Even with false, it should add blockhash if none exists
+      computeUnitLimitReset: false, // Disable estimation to avoid simulation errors
+    });
+
+    // Should add the blockhash even when blockhashReset is false
+    expect(prepared.lifetimeConstraint.blockhash).toBe(newBlockhash);
+    expect(prepared.lifetimeConstraint.lastValidBlockHeight).toBe(100n);
+  });
+
+  // Configuration combinations
+  it("should handle computeUnitLimitReset=true and blockhashReset=false", async () => {
+    const existingBlockhash = "9WzDXwBbmkg8ZTbNMqUxvQRAyrZzDsGYdLVL9zYtAWWM";
+
+    const transaction = pipe(
+      createTransactionMessage({ version: 0 }),
+      tx => setTransactionMessageFeePayerSigner(mockFeePayer, tx),
+      tx => ({
+        ...tx,
+        lifetimeConstraint: {
+          blockhash: existingBlockhash as Blockhash,
+          lastValidBlockHeight: 50n,
+        },
+      }),
+      tx => appendTransactionMessageInstruction(
+        getTransferSolInstruction({
+          source: mockFeePayer,
+          destination: mockDestination,
+          amount: 1_000_000n,
+        }),
+        tx
+      )
+    );
+
+    const mockRpc = {
+      getLatestBlockhash: () => ({
+        send: async () => ({
+          value: {
+            blockhash: "5eykt4UsFv8P8NJdTREpY1vzqKqZKvdpKuc147dw2N9d" as Blockhash,
+            lastValidBlockHeight: 100n,
+          },
+        }),
+      }),
+      simulateTransaction: () => ({
+        send: async () => ({
+          value: {
+            err: null,
+            unitsConsumed: 5000n,
+            logs: [],
+          },
+        }),
+      }),
+    } as Rpc<any>;
+
+    const prepared = await prepareTransaction({
+      transaction,
+      rpc: mockRpc,
+      computeUnitLimitReset: true, // Should estimate compute units
+      blockhashReset: false, // Should preserve existing blockhash
+    });
+
+    // Should preserve the original blockhash
+    expect(prepared.lifetimeConstraint.blockhash).toBe(existingBlockhash);
+    expect(prepared.lifetimeConstraint.lastValidBlockHeight).toBe(50n);
+
+    // Should have compute unit limit instruction added
+    const hasComputeUnitLimit = prepared.instructions.some(
+      ix => String(ix.programAddress) === String(COMPUTE_BUDGET_PROGRAM_ADDRESS) &&
+        ix.data && ix.data[0] === 2 // SetComputeUnitLimit instruction discriminator
+    );
+    expect(hasComputeUnitLimit).toBe(true);
+  });
+  it("should handle computeUnitLimitReset=false and blockhashReset=true", async () => {
+    const { updateOrAppendSetComputeUnitLimitInstruction } = await import("@solana-program/compute-budget");
+
+    const existingBlockhash = "9WzDXwBbmkg8ZTbNMqUxvQRAyrZzDsGYdLVL9zYtAWWM";
+    const newBlockhash = "5eykt4UsFv8P8NJdTREpY1vzqKqZKvdpKuc147dw2N9d";
+
+    const transaction = pipe(
+      createTransactionMessage({ version: 0 }),
+      tx => setTransactionMessageFeePayerSigner(mockFeePayer, tx),
+      tx => ({
+        ...tx,
+        lifetimeConstraint: {
+          blockhash: existingBlockhash as Blockhash,
+          lastValidBlockHeight: 50n,
+        },
+      }),
+      tx => updateOrAppendSetComputeUnitLimitInstruction(100_000, tx), // Pre-add compute limit
+      tx => appendTransactionMessageInstruction(
+        getTransferSolInstruction({
+          source: mockFeePayer,
+          destination: mockDestination,
+          amount: 1_000_000n,
+        }),
+        tx
+      )
+    );
+
+    const mockRpc = {
+      getLatestBlockhash: () => ({
+        send: async () => ({
+          value: {
+            blockhash: newBlockhash as Blockhash,
+            lastValidBlockHeight: 100n,
+          },
+        }),
+      }),
+      simulateTransaction: () => ({
+        send: async () => ({
+          value: {
+            err: null,
+            unitsConsumed: 5000n,
+            logs: [],
+          },
+        }),
+      }),
+    } as Rpc<any>;
+
+    const prepared = await prepareTransaction({
+      transaction,
+      rpc: mockRpc,
+      computeUnitLimitReset: false, // Should not estimate compute units
+      blockhashReset: true, // Should update blockhash
+    });
+
+    // Should use the new blockhash
+    expect(prepared.lifetimeConstraint.blockhash).toBe(newBlockhash);
+    expect(prepared.lifetimeConstraint.lastValidBlockHeight).toBe(100n);
+
+    // Should have kept the existing compute unit limit instruction (no re-estimation)
+    const computeLimitInstructions = prepared.instructions.filter(
+      ix => String(ix.programAddress) === String(COMPUTE_BUDGET_PROGRAM_ADDRESS) &&
+        ix.data && ix.data[0] === 2 // SetComputeUnitLimit instruction discriminator
+    );
+    expect(computeLimitInstructions.length).toBe(1);
+  });
+  it("should handle both computeUnitLimitReset=false and blockhashReset=false", async () => {
+    const { updateOrAppendSetComputeUnitLimitInstruction } = await import("@solana-program/compute-budget");
+
+    const existingBlockhash = "9WzDXwBbmkg8ZTbNMqUxvQRAyrZzDsGYdLVL9zYtAWWM";
+
+    const transaction = pipe(
+      createTransactionMessage({ version: 0 }),
+      tx => setTransactionMessageFeePayerSigner(mockFeePayer, tx),
+      tx => ({
+        ...tx,
+        lifetimeConstraint: {
+          blockhash: existingBlockhash as Blockhash,
+          lastValidBlockHeight: 50n,
+        },
+      }),
+      tx => updateOrAppendSetComputeUnitLimitInstruction(100_000, tx), // Pre-add compute limit
+      tx => appendTransactionMessageInstruction(
+        getTransferSolInstruction({
+          source: mockFeePayer,
+          destination: mockDestination,
+          amount: 1_000_000n,
+        }),
+        tx
+      )
+    );
+
+    const mockRpc = {
+      getLatestBlockhash: () => ({
+        send: async () => ({
+          value: {
+            blockhash: "5eykt4UsFv8P8NJdTREpY1vzqKqZKvdpKuc147dw2N9d" as Blockhash,
+            lastValidBlockHeight: 100n,
+          },
+        }),
+      }),
+      simulateTransaction: () => ({
+        send: async () => ({
+          value: {
+            err: null,
+            unitsConsumed: 5000n,
+            logs: [],
+          },
+        }),
+      }),
+    } as Rpc<any>;
+
+    const prepared = await prepareTransaction({
+      transaction,
+      rpc: mockRpc,
+      computeUnitLimitReset: false, // Should not estimate compute units
+      blockhashReset: false, // Should preserve existing blockhash
+    });
+
+    // Should preserve the original blockhash
+    expect(prepared.lifetimeConstraint.blockhash).toBe(existingBlockhash);
+    expect(prepared.lifetimeConstraint.lastValidBlockHeight).toBe(50n);
+
+    // Should have kept the existing compute unit limit instruction unchanged
+    const computeLimitInstructions = prepared.instructions.filter(
+      ix => String(ix.programAddress) === String(COMPUTE_BUDGET_PROGRAM_ADDRESS) &&
+        ix.data && ix.data[0] === 2 // SetComputeUnitLimit instruction discriminator
+    );
+    expect(computeLimitInstructions.length).toBe(1);
+  });
+
+  // Complex scenarios
+  it("should handle transactions that already have both compute limit and price instructions", async () => {
+    const { updateOrAppendSetComputeUnitLimitInstruction, updateOrAppendSetComputeUnitPriceInstruction } = await import("@solana-program/compute-budget");
+
+    const transaction = pipe(
+      createTransactionMessage({ version: 0 }),
+      tx => setTransactionMessageFeePayerSigner(mockFeePayer, tx),
+      tx => updateOrAppendSetComputeUnitLimitInstruction(80_000, tx), // Pre-add compute limit
+      tx => updateOrAppendSetComputeUnitPriceInstruction(1000n as MicroLamports, tx), // Pre-add priority fee
+      tx => appendTransactionMessageInstruction(
+        getTransferSolInstruction({
+          source: mockFeePayer,
+          destination: mockDestination,
+          amount: 1_000_000n,
+        }),
+        tx
+      )
+    );
+
+    const mockRpc = {
+      getLatestBlockhash: () => ({
+        send: async () => ({
+          value: {
+            blockhash: "9WzDXwBbmkg8ZTbNMqUxvQRAyrZzDsGYdLVL9zYtAWWM" as Blockhash,
+            lastValidBlockHeight: 100n,
+          },
+        }),
+      }),
+      simulateTransaction: () => ({
+        send: async () => ({
+          value: {
+            err: null,
+            unitsConsumed: 5000n,
+            logs: [],
+          },
+        }),
+      }),
+    } as Rpc<any>;
+
+    const prepared = await prepareTransaction({
+      transaction,
+      rpc: mockRpc,
+      computeUnitLimitReset: true, // Should re-estimate despite existing limit
+      computeUnitPrice: 2000n, // Should update the existing price
+    });
+
+    // Should still have both compute limit and price instructions
+    const computeBudgetInstructions = prepared.instructions.filter(
+      ix => String(ix.programAddress) === String(COMPUTE_BUDGET_PROGRAM_ADDRESS)
+    );
+    expect(computeBudgetInstructions.length).toBe(2);
+
+    // Should have updated limit through re-estimation (5000 * 1.1 = 5500)
+    const computeLimitInstruction = computeBudgetInstructions.find(
+      ix => ix.data && ix.data[0] === 2 // SetComputeUnitLimit instruction discriminator
+    );
+    expect(computeLimitInstruction).toBeDefined();
+
+    // Should have updated price instruction
+    const computePriceInstruction = computeBudgetInstructions.find(
+      ix => ix.data && ix.data[0] === 3 // SetComputeUnitPrice instruction discriminator
+    );
+    expect(computePriceInstruction).toBeDefined();
+  });
+
+  // Default values
+  it("should use default computeUnitLimitMultiplier of 1.1 when not specified", async () => {
+    const transaction = pipe(
+      createTransactionMessage({ version: 0 }),
+      tx => setTransactionMessageFeePayerSigner(mockFeePayer, tx),
+      tx => appendTransactionMessageInstruction(
+        getTransferSolInstruction({
+          source: mockFeePayer,
+          destination: mockDestination,
+          amount: 1_000_000n,
+        }),
+        tx
+      )
+    );
+
+    const mockRpc = {
+      getLatestBlockhash: () => ({
+        send: async () => ({
+          value: {
+            blockhash: "9WzDXwBbmkg8ZTbNMqUxvQRAyrZzDsGYdLVL9zYtAWWM" as Blockhash,
+            lastValidBlockHeight: 100n,
+          },
+        }),
+      }),
+      simulateTransaction: () => ({
+        send: async () => ({
+          value: {
+            err: null,
+            unitsConsumed: 10000n, // 10k * 1.1 = 11k
+            logs: [],
+          },
+        }),
+      }),
+    } as Rpc<any>;
+
+    const prepared = await prepareTransaction({
+      transaction,
+      rpc: mockRpc,
+      // No computeUnitLimitMultiplier specified - should default to 1.1
+    });
+
+    // Find the compute unit limit instruction and verify it used the 1.1 multiplier
+    const computeLimitInstruction = prepared.instructions.find(
+      ix => String(ix.programAddress) === String(COMPUTE_BUDGET_PROGRAM_ADDRESS) &&
+        ix.data && ix.data[0] === 2 // SetComputeUnitLimit instruction discriminator
+    );
+
+    expect(computeLimitInstruction).toBeDefined();
+    if (computeLimitInstruction?.data) {
+      // Extract units from instruction data (bytes 1-4 in little-endian format)
+      const unitsBytes = computeLimitInstruction.data.slice(1, 5);
+      const units = new DataView(unitsBytes.buffer).getUint32(0, true);
+      expect(units).toBe(11000); // 10000 * 1.1 = 11000
+    }
+  });
+
+});

--- a/packages/gill/src/core/prepare-transaction.ts
+++ b/packages/gill/src/core/prepare-transaction.ts
@@ -115,24 +115,16 @@ export async function prepareTransaction<TMessage extends PrepareCompilableTrans
   const shouldEstimate = config.computeUnitLimitReset || !hasComputeUnitLimit;
 
   if (shouldEstimate) {
-    try {
-      // Use estimateComputeUnitLimitFactory which handles provisional blockhash and max CU for simulation
-      const estimateComputeUnitLimit = estimateComputeUnitLimitFactory({ rpc: config.rpc });
-      const consumedUnits = await estimateComputeUnitLimit(transaction);
-
-      // Calculate compute units with multiplier
-      const estimatedUnits = Math.ceil(consumedUnits * computeUnitLimitMultiplier);
-      // Ensure our multiplier doesn't exceed the max compute unit limit
-      const finalUnits = Math.min(estimatedUnits, MAX_COMPUTE_UNIT_LIMIT);
-
-      debug(`Compute units - consumed: ${consumedUnits}, estimated: ${estimatedUnits}, final: ${finalUnits}`, "debug");
-
-      // Update transaction with estimated compute units
-      transaction = updateOrAppendSetComputeUnitLimitInstruction(finalUnits, transaction) as TMessage;
-    } catch (error) {
-      debug(`Failed to estimate compute units: ${error}`, "error");
-      throw error;
-    }
+    // Use estimateComputeUnitLimitFactory which handles provisional blockhash and max CU for simulation
+    const estimateComputeUnitLimit = estimateComputeUnitLimitFactory({ rpc: config.rpc });
+    const consumedUnits = await estimateComputeUnitLimit(transaction);
+    // Calculate compute units with multiplier
+    const estimatedUnits = Math.ceil(consumedUnits * computeUnitLimitMultiplier);
+    // Ensure our multiplier doesn't exceed the max compute unit limit
+    const finalUnits = Math.min(estimatedUnits, MAX_COMPUTE_UNIT_LIMIT);
+    debug(`Compute units - consumed: ${consumedUnits}, estimated: ${estimatedUnits}, final: ${finalUnits}`, "debug");
+    // Update transaction with estimated compute units
+    transaction = updateOrAppendSetComputeUnitLimitInstruction(finalUnits, transaction) as TMessage;
   }
 
   // Update the latest blockhash

--- a/packages/gill/src/core/prepare-transaction.ts
+++ b/packages/gill/src/core/prepare-transaction.ts
@@ -1,17 +1,23 @@
-import { COMPUTE_BUDGET_PROGRAM_ADDRESS, getSetComputeUnitLimitInstruction } from "@solana-program/compute-budget";
+import { 
+  updateOrAppendSetComputeUnitLimitInstruction,
+  updateOrAppendSetComputeUnitPriceInstruction,
+  estimateComputeUnitLimitFactory,
+  MAX_COMPUTE_UNIT_LIMIT,
+  COMPUTE_BUDGET_PROGRAM_ADDRESS,
+} from "@solana-program/compute-budget";
 import type {
   CompilableTransactionMessage,
   GetLatestBlockhashApi,
-  ITransactionMessageWithFeePayer,
+  TransactionMessageWithFeePayer,
   Rpc,
   SimulateTransactionApi,
   TransactionMessage,
   TransactionMessageWithBlockhashLifetime,
+  MicroLamports,
+  Blockhash,
 } from "@solana/kit";
 import {
-  appendTransactionMessageInstruction,
   assertIsTransactionMessageWithBlockhashLifetime,
-  getComputeUnitEstimateForTransactionMessageFactory,
   setTransactionMessageLifetimeUsingBlockhash,
 } from "@solana/kit";
 import { isSetComputeLimitInstruction } from "../programs/compute-budget";
@@ -20,7 +26,12 @@ import { debug, isDebugEnabled } from "./debug";
 
 type PrepareCompilableTransactionMessage =
   | CompilableTransactionMessage
-  | (ITransactionMessageWithFeePayer & TransactionMessage);
+  | (TransactionMessageWithFeePayer & TransactionMessage);
+
+const SIMULATION_BLOCKHASH = {
+  blockhash: '11111111111111111111111111111111' as Blockhash,
+  lastValidBlockHeight: 0n,
+}
 
 export type PrepareTransactionConfig<TMessage extends PrepareCompilableTransactionMessage> = {
   /**
@@ -40,8 +51,15 @@ export type PrepareTransactionConfig<TMessage extends PrepareCompilableTransacti
   /**
    * Whether or not you wish to force reset the compute unit limit value (if one is already set)
    * using the simulation response and `computeUnitLimitMultiplier`
+   * (to avoid a simulation, you must set this to false and set a compute unit limit instruction before calling this function)
    **/
   computeUnitLimitReset?: boolean;
+  /**
+   * Priority fee to set for the transaction (in microlamports per compute unit)
+   * 
+   * If not provided, no compute unit price instruction will be added
+   **/
+  computeUnitPrice?: MicroLamports | bigint | number;
   /**
    * Whether or not you wish to force reset the latest blockhash (if one is already set)
    *
@@ -51,76 +69,124 @@ export type PrepareTransactionConfig<TMessage extends PrepareCompilableTransacti
 };
 
 /**
+ * Validate the prepare transaction config
+ * @param config - The prepare transaction config
+ * @throws Error if the config is invalid
+ */
+function validatePrepareTransactionConfig(config: PrepareTransactionConfig<any>) {
+  if (config.computeUnitLimitMultiplier && config.computeUnitLimitMultiplier <= 1) {
+    throw new Error("computeUnitLimitMultiplier must be >= 1");
+  }
+
+  if (config.computeUnitPrice !== undefined) {
+    const price = typeof config.computeUnitPrice === 'bigint'
+      ? config.computeUnitPrice
+      : BigInt(config.computeUnitPrice);
+
+    if (price < 0n) {
+      throw new Error("computeUnitPrice must be >= 0");
+    }
+  }
+}
+
+/**
+ * Check if the transaction has a compute unit limit instruction
+ * @param transaction - The transaction to check
+ * @returns True if the transaction has a compute unit limit instruction, false otherwise
+ */
+function hasComputeUnitInstruction(transaction: TransactionMessage) {
+  return transaction.instructions.some((ix) => 
+    ix.programAddress === COMPUTE_BUDGET_PROGRAM_ADDRESS && isSetComputeLimitInstruction(ix)
+  );
+}
+
+/**
  * Prepare a Transaction to be signed and sent to the network. Including:
- * - setting a compute unit limit (if not already set)
+ * - setting a compute unit price (priority fee) if provided
+ * - setting a compute unit limit (via simulation if needed)
  * - fetching the latest blockhash (if not already set)
- * - (optional) simulating and resetting the compute unit limit
  * - (optional) resetting latest blockhash to the most recent
  */
 export async function prepareTransaction<TMessage extends PrepareCompilableTransactionMessage>(
   config: PrepareTransactionConfig<TMessage>,
 ): Promise<TMessage & TransactionMessageWithBlockhashLifetime> {
+  validatePrepareTransactionConfig(config);
   // set the config defaults
-  if (!config.computeUnitLimitMultiplier) config.computeUnitLimitMultiplier = 1.1;
-  if (config.blockhashReset !== false) config.blockhashReset = true;
+  const computeUnitLimitMultiplier = config.computeUnitLimitMultiplier ?? 1.1;
+  const blockhashReset = config.blockhashReset ?? true;
+  
+  let transaction = config.transaction;
 
-  const computeBudgetIndex = {
-    limit: -1,
-    price: -1,
-  };
+  // Add compute unit price instruction if provided
+  if (config.computeUnitPrice !== undefined) {
+    const microLamports = typeof config.computeUnitPrice === 'bigint' 
+      ? config.computeUnitPrice as MicroLamports
+      : BigInt(config.computeUnitPrice) as MicroLamports;
+    
+    transaction = updateOrAppendSetComputeUnitPriceInstruction(microLamports, transaction) as TMessage;
+  }
 
-  config.transaction.instructions.map((ix, index) => {
-    if (ix.programAddress != COMPUTE_BUDGET_PROGRAM_ADDRESS) return;
+  // Check if transaction already has a compute unit limit instruction
+  const hasComputeUnitLimit = hasComputeUnitInstruction(transaction);
 
-    if (isSetComputeLimitInstruction(ix)) {
-      computeBudgetIndex.limit = index;
+  // Determine if we should estimate compute units
+  const shouldEstimate = config.computeUnitLimitReset || !hasComputeUnitLimit;
+
+  if (shouldEstimate) {
+    // First, ensure we have a blockhash for simulation
+    let simulationTransaction = transaction;
+    if (!("lifetimeConstraint" in simulationTransaction)) {
+      simulationTransaction = setTransactionMessageLifetimeUsingBlockhash(SIMULATION_BLOCKHASH, simulationTransaction) as TMessage;
     }
-    // else if (isSetComputeUnitPriceInstruction(ix)) {
-    //   computeBudgetIndex.price = index;
-    // }
-  });
 
-  // set a compute unit limit instruction
-  if (computeBudgetIndex.limit < 0 || config.computeUnitLimitReset) {
-    const units = await getComputeUnitEstimateForTransactionMessageFactory({ rpc: config.rpc })(config.transaction);
-    debug(`Obtained compute units from simulation: ${units}`, "debug");
-    const ix = getSetComputeUnitLimitInstruction({
-      units: units * config.computeUnitLimitMultiplier,
-    });
+    // Add max compute units for simulation to get accurate estimate
+    simulationTransaction = updateOrAppendSetComputeUnitLimitInstruction(
+      MAX_COMPUTE_UNIT_LIMIT, 
+      simulationTransaction
+    ) as TMessage;
 
-    if (computeBudgetIndex.limit < 0) {
-      config.transaction = appendTransactionMessageInstruction(ix, config.transaction) as unknown as TMessage;
-    } else if (config.computeUnitLimitReset) {
-      const nextInstructions = [...config.transaction.instructions];
-      nextInstructions.splice(computeBudgetIndex.limit, 1, ix);
-      config.transaction = Object.freeze({
-        ...config.transaction,
-        instructions: nextInstructions,
-      } as TMessage);
+    try {
+      // Simulate the transaction
+      const getComputeUnitEstimate = estimateComputeUnitLimitFactory({ rpc: config.rpc });
+      const consumedUnits = await getComputeUnitEstimate(simulationTransaction);
+
+      // Calculate compute units with multiplier
+      const estimatedUnits = Math.ceil(consumedUnits * computeUnitLimitMultiplier);
+      // Ensure our multiplier doesn't exceed the max compute unit limit
+      const finalUnits = Math.min(estimatedUnits, MAX_COMPUTE_UNIT_LIMIT);
+
+      debug(`Compute units - consumed: ${consumedUnits}, estimated: ${estimatedUnits}, final: ${finalUnits}`, "debug");
+
+      // Update transaction with estimated compute units
+      transaction = updateOrAppendSetComputeUnitLimitInstruction(finalUnits, transaction) as TMessage;
+    } catch (error) {
+      debug(`Failed to estimate compute units: ${error}`, "error");
+      throw error;
     }
   }
 
-  // update the latest blockhash
-  if (config.blockhashReset || "lifetimeConstraint" in config.transaction == false) {
+  // Update the latest blockhash
+  if (blockhashReset || !("lifetimeConstraint" in transaction)) {
     const { value: latestBlockhash } = await config.rpc.getLatestBlockhash().send();
-    if ("lifetimeConstraint" in config.transaction == false) {
+    
+    if (!("lifetimeConstraint" in transaction)) {
       debug("Transaction missing latest blockhash, fetching one.", "debug");
-      config.transaction = setTransactionMessageLifetimeUsingBlockhash(latestBlockhash, config.transaction) as unknown as TMessage;
-    } else if (config.blockhashReset) {
+      transaction = setTransactionMessageLifetimeUsingBlockhash(latestBlockhash, transaction) as TMessage & TransactionMessageWithBlockhashLifetime;
+    } else if (blockhashReset) {
       debug("Auto resetting the latest blockhash.", "debug");
-      config.transaction = Object.freeze({
-        ...config.transaction,
+      transaction = {
+        ...transaction,
         lifetimeConstraint: latestBlockhash,
-      } as TransactionMessageWithBlockhashLifetime & typeof config.transaction);
+      } as TMessage & TransactionMessageWithBlockhashLifetime;
     }
   }
 
-  assertIsTransactionMessageWithBlockhashLifetime(config.transaction);
+  assertIsTransactionMessageWithBlockhashLifetime(transaction);
 
-  // skip the async call if debugging is off
+  // Log base64 transaction if debugging is enabled
   if (isDebugEnabled()) {
-    debug(`Transaction as base64: ${await transactionToBase64WithSigners(config.transaction)}`, "debug");
+    debug(`Transaction as base64: ${await transactionToBase64WithSigners(transaction)}`, "debug");
   }
 
-  return config.transaction;
+  return transaction;
 }


### PR DESCRIPTION
Refactor `prepareTransaction` function to improve functionality, add priority fee support, and utilize latest compute budget utilities.

### Problem
The `prepareTransaction` function is not using the latest `@solana-program/compute-budget` helpers. Additionally it does not support priority fees--which can be a problem if someone calls `prepareTransaction` to estimate CUs, then adds priorty fees after.

### Summary of Changes
- Improved compute unit estimation: Now uses `estimateComputeUnitLimitFactory`, `updateOrAppend` instructions, and other helps from `@solana-program/compute-budget` for more cleaner log and instruction management
- Priority fee support: Added `computeUnitPrice` parameter to set transaction priority fees (accepts MicroLamports, bigint, or number) -- this is important to ensure CU estimates happen before someone adds priority fees w/ `createTransaction`
- Added input validation
- Ensures margin-adjusted CU limit never exceeds `MAX_COMPUTE_UNIT_LIMIT`
- Add unit test coverage

