### PR TITLE
Adds getConfirmedTransaction and ConfirmedTransaction helper types

### DIFF
--- a/.changeset/pretty-moles-speak.md
+++ b/.changeset/pretty-moles-speak.md
@@ -1,0 +1,5 @@
+---
+"gill": patch
+---
+
+Adds getConfirmedTransaction and ConfirmedTransaction helper types

--- a/packages/gill/src/core/get-confirmed-transaction.ts
+++ b/packages/gill/src/core/get-confirmed-transaction.ts
@@ -1,0 +1,22 @@
+import type { GetTransactionApi, Rpc, Signature } from "@solana/kit";
+
+/**
+ * Gets a confirmed transaction from the blockchain with parsed JSON encoding
+ * @param rpc - The RPC client with GetTransactionApi
+ * @param signature - The transaction signature to fetch
+ * @returns The transaction details or null if not found
+ */
+export const getConfirmedTransaction = async (rpc: Rpc<GetTransactionApi>, signature: Signature) => {
+  return await rpc
+    .getTransaction(signature, {
+      commitment: "confirmed",
+      encoding: "jsonParsed",
+      maxSupportedTransactionVersion: 0,
+    })
+    .send();
+};
+
+/**
+ * Type for a confirmed transaction fetched from the blockchain
+ */
+export type ConfirmedTransaction = NonNullable<Awaited<ReturnType<typeof getConfirmedTransaction>>>;

--- a/packages/gill/src/core/index.ts
+++ b/packages/gill/src/core/index.ts
@@ -17,3 +17,4 @@ export * from "./simulate-transaction";
 export * from "./get-oldest-signature";
 export * from "./insert-reference-key";
 export * from "./create-codama-config";
+export * from "./get-confirmed-transaction";


### PR DESCRIPTION
- **Adds getConfirmedTransaction and ConfirmedTransaction helper types**
- **Changeset**

### Problem

The TypeScript types for getting a JSON parsed transaction are very complex. This simplifies them and adds a helper for fetching them.

### Summary of Changes



Fixes #