### PR TITLE
Fix: remove base58 encoding from the useProgramAccounts hook

### DIFF
--- a/.changeset/itchy-dryers-laugh.md
+++ b/.changeset/itchy-dryers-laugh.md
@@ -1,0 +1,5 @@
+---
+"@gillsdk/react": minor
+---
+
+update `useProgramAccounts` hook by removeing the base58 encodings

--- a/.changeset/itchy-dryers-laugh.md
+++ b/.changeset/itchy-dryers-laugh.md
@@ -2,4 +2,4 @@
 "@gillsdk/react": minor
 ---
 
-update `useProgramAccounts` hook by removeing the base58 encodings
+update `useProgramAccounts` hook by removing the base58 encodings

--- a/.changeset/slow-ants-wash.md
+++ b/.changeset/slow-ants-wash.md
@@ -2,4 +2,4 @@
 "gill": patch
 ---
 
-update kit imports to not use deprecated "I" symbols
+update `useProgramAccounts` hook by removeing the base58 encodings

--- a/.changeset/slow-ants-wash.md
+++ b/.changeset/slow-ants-wash.md
@@ -2,4 +2,4 @@
 "gill": patch
 ---
 
-update `useProgramAccounts` hook by removeing the base58 encodings
+update kit imports to not use deprecated "I" symbols

--- a/packages/react/src/__typeset__/program-accounts.ts
+++ b/packages/react/src/__typeset__/program-accounts.ts
@@ -1,11 +1,10 @@
 import {
-  AccountInfoWithBase58EncodedData,
   AccountInfoWithBase64EncodedData,
   AccountInfoWithBase64EncodedZStdCompressedData,
   AccountInfoWithJsonData,
   Address,
   Base58EncodedBytes,
-  Base58EncodedDataResponse,
+  Base64EncodedBytes,
   SolanaRpcResponse,
 } from "gill";
 import { useProgramAccounts } from "../hooks/program-accounts";
@@ -17,7 +16,7 @@ import { useProgramAccounts } from "../hooks/program-accounts";
   // default encoded data as bytes
   {
     const { accounts: baseConfigAccounts } = useProgramAccounts({ program });
-    baseConfigAccounts[0].account.data satisfies Base58EncodedBytes;
+    baseConfigAccounts[0].account.data satisfies Base64EncodedBytes;
 
     const { accounts: baseConfigAccounts2 } = useProgramAccounts({
       program,
@@ -25,7 +24,7 @@ import { useProgramAccounts } from "../hooks/program-accounts";
         commitment: "finalized",
       },
     });
-    baseConfigAccounts2[0].account.data satisfies Base58EncodedBytes;
+    baseConfigAccounts2[0].account.data satisfies Base64EncodedBytes;
 
     const { accounts: baseConfigContextAccounts } = useProgramAccounts({
       program,
@@ -36,33 +35,7 @@ import { useProgramAccounts } from "../hooks/program-accounts";
 
     // Should include context in response
     baseConfigContextAccounts satisfies SolanaRpcResponse<any>;
-    baseConfigContextAccounts.value[0].account.data satisfies Base58EncodedBytes;
-  }
-
-  // base58 encoded `data`
-  {
-    const { accounts: base58Accounts } = useProgramAccounts({
-      program,
-      config: {
-        encoding: "base58",
-      },
-    });
-    base58Accounts[0].account.data satisfies Base58EncodedDataResponse;
-
-    const { accounts: base58ContextAccounts } = useProgramAccounts({
-      program,
-      config: {
-        encoding: "base58",
-        withContext: true,
-      },
-    });
-
-    // Should include context in response
-    base58ContextAccounts satisfies SolanaRpcResponse<any>;
-    base58ContextAccounts.value[0].account satisfies AccountInfoWithBase58EncodedData;
-
-    // @ts-expect-error Should not be base58 encoded bytes
-    base58ContextAccounts.value[0].account.data satisfies Base58EncodedBytes;
+    baseConfigContextAccounts.value[0].account.data satisfies Base64EncodedBytes;
   }
 
   // base64 encoded `data`

--- a/packages/react/src/__typeset__/program-accounts.ts
+++ b/packages/react/src/__typeset__/program-accounts.ts
@@ -4,7 +4,6 @@ import {
   AccountInfoWithJsonData,
   Address,
   Base58EncodedBytes,
-  Base64EncodedBytes,
   SolanaRpcResponse,
 } from "gill";
 import { useProgramAccounts } from "../hooks/program-accounts";
@@ -16,7 +15,7 @@ import { useProgramAccounts } from "../hooks/program-accounts";
   // default encoded data as bytes
   {
     const { accounts: baseConfigAccounts } = useProgramAccounts({ program });
-    baseConfigAccounts[0].account.data satisfies Base64EncodedBytes;
+    baseConfigAccounts[0].account.data satisfies AccountInfoWithBase64EncodedData["data"];
 
     const { accounts: baseConfigAccounts2 } = useProgramAccounts({
       program,
@@ -24,7 +23,7 @@ import { useProgramAccounts } from "../hooks/program-accounts";
         commitment: "finalized",
       },
     });
-    baseConfigAccounts2[0].account.data satisfies Base64EncodedBytes;
+    baseConfigAccounts2[0].account.data satisfies AccountInfoWithBase64EncodedData["data"];
 
     const { accounts: baseConfigContextAccounts } = useProgramAccounts({
       program,
@@ -35,7 +34,7 @@ import { useProgramAccounts } from "../hooks/program-accounts";
 
     // Should include context in response
     baseConfigContextAccounts satisfies SolanaRpcResponse<any>;
-    baseConfigContextAccounts.value[0].account.data satisfies Base64EncodedBytes;
+    baseConfigContextAccounts.value[0].account satisfies AccountInfoWithBase64EncodedData;
   }
 
   // base64 encoded `data`

--- a/packages/react/src/hooks/program-accounts.ts
+++ b/packages/react/src/hooks/program-accounts.ts
@@ -3,8 +3,6 @@
 import { useQuery } from "@tanstack/react-query";
 import type {
   AccountInfoBase,
-  AccountInfoWithBase58Bytes,
-  AccountInfoWithBase58EncodedData,
   AccountInfoWithBase64EncodedData,
   AccountInfoWithBase64EncodedZStdCompressedData,
   AccountInfoWithJsonData,
@@ -18,7 +16,7 @@ import { GILL_HOOK_CLIENT_KEY } from "../const";
 import { useSolanaClient } from "./client";
 import type { GillUseRpcHook } from "./types";
 
-type Encoding = "base64" | "jsonParsed" | "base64+zstd" | "base58";
+type Encoding = "base64" | "jsonParsed" | "base64+zstd";
 
 type RpcConfig = Simplify<
   Parameters<GetProgramAccountsApi["getProgramAccounts"]>[1] &
@@ -50,14 +48,9 @@ type UseProgramAccountsResponse<TConfig extends RpcConfig> = TConfig extends {
           ? SolanaRpcResponse<AccountInfoWithPubkey<AccountInfoBase & AccountInfoWithJsonData>[]>
           : TConfig extends { encoding: "jsonParsed" }
             ? AccountInfoWithPubkey<AccountInfoBase & AccountInfoWithJsonData>[]
-            : TConfig extends { encoding: "base58"; withContext: true }
-              ? SolanaRpcResponse<AccountInfoWithPubkey<AccountInfoBase & AccountInfoWithBase58EncodedData>[]>
-              : TConfig extends { encoding: "base58" }
-                ? AccountInfoWithPubkey<AccountInfoBase & AccountInfoWithBase58EncodedData>[]
-                : TConfig extends { withContext: true }
-                  ? SolanaRpcResponse<AccountInfoWithPubkey<AccountInfoBase & AccountInfoWithBase58Bytes>[]>
-                  : AccountInfoWithPubkey<AccountInfoBase & AccountInfoWithBase58Bytes>[];
-
+            : TConfig extends { withContext: true }
+              ? SolanaRpcResponse<AccountInfoWithPubkey<AccountInfoBase>>[]
+              : AccountInfoWithPubkey<AccountInfoBase & AccountInfoWithJsonData>[];
 /**
  * Get all the accounts owned by a `program` using the Solana RPC method of
  * [`getProgramAccounts`](https://solana.com/docs/rpc/http/getprogramaccounts)

--- a/packages/react/src/hooks/program-accounts.ts
+++ b/packages/react/src/hooks/program-accounts.ts
@@ -49,8 +49,8 @@ type UseProgramAccountsResponse<TConfig extends RpcConfig> = TConfig extends {
           : TConfig extends { encoding: "jsonParsed" }
             ? AccountInfoWithPubkey<AccountInfoBase & AccountInfoWithJsonData>[]
             : TConfig extends { withContext: true }
-              ? SolanaRpcResponse<AccountInfoWithPubkey<AccountInfoBase>>[]
-              : AccountInfoWithPubkey<AccountInfoBase & AccountInfoWithJsonData>[];
+              ? SolanaRpcResponse<AccountInfoWithPubkey<AccountInfoBase & AccountInfoWithBase64EncodedData>[]>
+              : AccountInfoWithPubkey<AccountInfoBase & AccountInfoWithBase64EncodedData>[];
 /**
  * Get all the accounts owned by a `program` using the Solana RPC method of
  * [`getProgramAccounts`](https://solana.com/docs/rpc/http/getprogramaccounts)


### PR DESCRIPTION
### Problem
 as mentioned in issue #225 base58 encodings are deprecated by solana runtime so we need to remove them from the `useProgramAccounts` hook 


### Summary of Changes
- removed the base58 encoding options from the `useProgramAccounts` hook 
- update the `program-accounts.ts` in `__typeset__` by removing the types related to base58
- updated the `.changeset` patch 
