### PR TITLE
fix:codama-client-generation

### DIFF
--- a/packages/gill/src/__tests__/create-codama.config.ts
+++ b/packages/gill/src/__tests__/create-codama.config.ts
@@ -38,6 +38,7 @@ describe("createCodamaConfig", () => {
         },
       },
     });
+    expect(config.scripts).not.toHaveProperty("rust");
   });
 
   it("should return accept rust client", () => {

--- a/packages/gill/src/__tests__/create-codama.config.ts
+++ b/packages/gill/src/__tests__/create-codama.config.ts
@@ -36,7 +36,6 @@ describe("createCodamaConfig", () => {
           ],
           from: "@codama/renderers-js",
         },
-        rust: undefined,
       },
     });
   });

--- a/packages/gill/src/core/create-codama-config.ts
+++ b/packages/gill/src/core/create-codama-config.ts
@@ -49,18 +49,18 @@ export function createCodamaConfig({
         args: [clientJs, { dependencyMap }],
         from: "@codama/renderers-js",
       },
-      rust: clientRust
-        ? {
-            from: "@codama/renderers-rust",
-            args: [
-              clientRust,
-              {
-                crateFolder: "clients/rust",
-                formatCode: true,
-              },
-            ],
-          }
-        : undefined,
+      ...(clientRust && {
+        rust: {
+          from: "@codama/renderers-rust",
+          args: [
+            clientRust,
+            {
+              crateFolder: "clients/rust",
+              formatCode: true,
+            },
+          ],
+        },
+      }),
     },
   };
 }


### PR DESCRIPTION
### Problem

`createCodamaConfig` fails when no `clientRust` argument is provided. In this case, the function inserts `rust: undefined` into the scripts object, which causes `codama run js` to throw:

```bash
✖ Cannot read properties of undefined (reading 'from')
```

This forces users to provide a `clientRust` path, even when they are only interested in generating JS clients.


### Summary of Changes
```ts
 ...(clientRust && {
    rust: {
      from: "@codama/renderers-rust",
      args: [
        clientRust,
        {
          crateFolder: "clients/rust",
          formatCode: true,
        },
      ],
    },
  }),
```

**Explanation:**

If `clientRust` argument is provided, the rust config is included. 
If not, nothing is spread, meaning scripts contains only js.
This avoids `rust: undefined` in the object, which previously caused runtime errors.

Also updated tests to fit.

Fixes #207