### PR TITLE
fix: ensure `createCodamaConfig` returns a valid object

### DIFF
--- a/.changeset/unlucky-knives-sleep.md
+++ b/.changeset/unlucky-knives-sleep.md
@@ -1,0 +1,5 @@
+---
+"gill": patch
+---
+
+ensure createCodamaConfig returns a valid object

--- a/packages/gill/src/__tests__/create-codama.config.ts
+++ b/packages/gill/src/__tests__/create-codama.config.ts
@@ -36,16 +36,15 @@ describe("createCodamaConfig", () => {
           ],
           from: "@codama/renderers-js",
         },
-        rust: undefined,
       },
     });
   });
 
   it("should return accept rust client", () => {
     const config = createCodamaConfig({
-      idl,
       clientJs,
       clientRust,
+      idl,
     });
 
     expect(config).toMatchObject({
@@ -74,7 +73,6 @@ describe("createCodamaConfig", () => {
           from: "@codama/renderers-js",
         },
         rust: {
-          from: "@codama/renderers-rust",
           args: [
             clientRust,
             {
@@ -82,6 +80,7 @@ describe("createCodamaConfig", () => {
               formatCode: true,
             },
           ],
+          from: "@codama/renderers-rust",
         },
       },
     });

--- a/packages/gill/src/core/create-codama-config.ts
+++ b/packages/gill/src/core/create-codama-config.ts
@@ -37,10 +37,10 @@ export function createCodamaConfig({
   clientRust,
   dependencyMap = GILL_EXTERNAL_MODULE_MAP,
 }: {
-  idl: string;
   clientJs: string;
   clientRust?: string;
   dependencyMap?: Record<string, string>;
+  idl: string;
 }) {
   return {
     idl,
@@ -49,18 +49,20 @@ export function createCodamaConfig({
         args: [clientJs, { dependencyMap }],
         from: "@codama/renderers-js",
       },
-      rust: clientRust
+      ...(clientRust
         ? {
-            from: "@codama/renderers-rust",
-            args: [
-              clientRust,
-              {
-                crateFolder: "clients/rust",
-                formatCode: true,
-              },
-            ],
+            rust: {
+              args: [
+                clientRust,
+                {
+                  crateFolder: "clients/rust",
+                  formatCode: true,
+                },
+              ],
+              from: "@codama/renderers-rust",
+            },
           }
-        : undefined,
+        : {}),
     },
   };
 }


### PR DESCRIPTION
### Problem

The update to `createCodamaConfig` in #178 breaks generation of js-only codama clients by adding a `rust` key with the value of `undefined`.  

### Summary of Changes

Ensure `rust: undefined` does not get added when no rust client is defined.


Fixes #207 