### PR TITLE
feat: add ensureAta helper function for associated token account crea…

### DIFF
--- a/packages/gill/src/programs/token/helpers/ensure-ata.ts
+++ b/packages/gill/src/programs/token/helpers/ensure-ata.ts
@@ -1,0 +1,59 @@
+import { getCreateAssociatedTokenIdempotentInstruction } from "@solana-program/token-2022";
+import type { Address, IInstruction, TransactionSigner } from "@solana/kit";
+import { assertAccountExists, fetchEncodedAccount } from "@solana/kit";
+import { checkedAddress } from "../../../core/utils";
+import type { Plan } from "../../../types";
+import { checkedTokenProgramAddress, getAssociatedTokenAccountAddress } from "../addresses";
+
+type EnsureAtaInput = {
+  owner: Address | TransactionSigner;
+  mint: Address | TransactionSigner;
+  tokenProgram?: Address;
+  feePayer?: TransactionSigner;
+  rpc?: Parameters<typeof fetchEncodedAccount>[0];
+};
+
+export async function ensureAta({ owner, mint, tokenProgram, feePayer, rpc }: EnsureAtaInput): Promise<Plan<{ ata: Address }>> {
+  tokenProgram = checkedTokenProgramAddress(tokenProgram);
+  const ata = await getAssociatedTokenAccountAddress(mint, owner, tokenProgram);
+
+  // If no RPC is provided, default to idempotent create instruction
+  if (!rpc) {
+    const ixs: IInstruction[] = feePayer
+      ? [
+          getCreateAssociatedTokenIdempotentInstruction({
+            owner: checkedAddress(owner),
+            mint: checkedAddress(mint),
+            ata,
+            payer: feePayer,
+            tokenProgram,
+          }),
+        ]
+      : [];
+
+    return { ixs, artifacts: { ata } };
+  }
+
+  // With RPC: check if ATA exists; if it does, return empty ixs
+  try {
+    const account = await fetchEncodedAccount(rpc, ata);
+    assertAccountExists(account);
+    return { ixs: [], artifacts: { ata } };
+  } catch {
+    // If account not found or other errors, fall back to idempotent create if feePayer present
+    const ixs: IInstruction[] = feePayer
+      ? [
+          getCreateAssociatedTokenIdempotentInstruction({
+            owner: checkedAddress(owner),
+            mint: checkedAddress(mint),
+            ata,
+            payer: feePayer,
+            tokenProgram,
+          }),
+        ]
+      : [];
+    return { ixs, artifacts: { ata } };
+  }
+}
+
+

--- a/packages/gill/src/programs/token/helpers/index.ts
+++ b/packages/gill/src/programs/token/helpers/index.ts
@@ -1,0 +1,2 @@
+export * from "./ensure-ata";
+

--- a/packages/gill/src/programs/token/index.ts
+++ b/packages/gill/src/programs/token/index.ts
@@ -1,5 +1,7 @@
 export * from "./addresses";
+export * from "./helpers";
 export * from "./instructions";
 export * from "./reexports";
 export * from "./transactions";
 export * from "./ui-amount";
+

--- a/packages/gill/src/types/transactions.ts
+++ b/packages/gill/src/types/transactions.ts
@@ -1,12 +1,12 @@
 import type {
   Address,
   BaseTransactionMessage,
-  Instruction,
+  IInstruction,
+  ITransactionMessageWithFeePayer,
+  ITransactionMessageWithFeePayerSigner,
   TransactionMessageWithBlockhashLifetime,
-  TransactionMessageWithFeePayer,
-  TransactionMessageWithFeePayerSigner,
   TransactionSigner,
-  TransactionVersion,
+  TransactionVersion
 } from "@solana/kit";
 import type { Simplify } from ".";
 
@@ -24,7 +24,7 @@ export type CreateTransactionInput<
    * */
   version?: TVersion;
   /** List of instructions for this transaction */
-  instructions: Instruction[];
+  instructions: IInstruction[];
   /** Address or Signer that will pay transaction fees */
   feePayer: TFeePayer;
   /**
@@ -40,10 +40,15 @@ export type CreateTransactionInput<
 
 export type FullTransaction<
   TVersion extends TransactionVersion,
-  TFeePayer extends TransactionMessageWithFeePayer | TransactionMessageWithFeePayerSigner,
+  TFeePayer extends ITransactionMessageWithFeePayer | ITransactionMessageWithFeePayerSigner,
   TBlockhashLifetime extends TransactionMessageWithBlockhashLifetime | undefined = undefined,
 > = Simplify<
   BaseTransactionMessage<TVersion> &
     TFeePayer &
     (TBlockhashLifetime extends TransactionMessageWithBlockhashLifetime ? TransactionMessageWithBlockhashLifetime : {})
 >;
+
+export type Plan<TArtifacts = {}> = {
+  ixs: IInstruction[];
+  artifacts: TArtifacts;
+};


### PR DESCRIPTION
## Problem

- Repeated logic across builders to derive an ATA and conditionally include a create-ATA instruction.
- No lightweight pattern to return both instructions and derived artifacts together.

## Summary of Changes

- Added Plan<T> type to return { ixs: IInstruction[]; artifacts: T }.
- Implemented ensureAta({ owner, mint, tokenProgram?, feePayer?, rpc? }):
 a. Derives artifacts.ata.
 b. If rpc provided and ATA exists → returns ixs: [].
 c. Otherwise returns a single idempotent create-ATA instruction when feePayer is provided.
- Exported helper via gill/programs.
- Followed existing patterns for token program checks and error handling.

Key files: 
- ```packages/gill/src/types/transactions.ts``` (add Plan<T>, switch to IInstruction)
- ```packages/gill/src/programs/token/helpers/ensure-ata.ts```
- ```packages/gill/src/programs/token/helpers/index.ts```
- ```packages/gill/src/programs/token/index.ts```