### PR TITLE
Use watch program logs hook

### DIFF
--- a/packages/react/src/hooks/index.ts
+++ b/packages/react/src/hooks/index.ts
@@ -3,6 +3,7 @@ export * from "./balance.js";
 export * from "./client.js";
 export * from "./latest-blockhash.js";
 export * from "./program-accounts.js";
+export * from "./program-logs.js";
 export * from "./recent-prioritization-fees.js";
 export * from "./signature-statuses.js";
 export * from "./signatures-for-address.js";

--- a/packages/react/src/hooks/program-logs.ts
+++ b/packages/react/src/hooks/program-logs.ts
@@ -1,11 +1,10 @@
 "use client";
 
-import type { Address } from "gill";
+import type { Address, Commitment } from "gill";
 import { useCallback, useEffect, useRef, useState } from "react";
 import { useSolanaClient } from "./client.js";
 
 type LogFilter = "all" | "error" | "success";
-type Commitment = "processed" | "confirmed" | "finalized";
 
 export type ProgramLog = {
   signature: string;

--- a/packages/react/src/hooks/program-logs.ts
+++ b/packages/react/src/hooks/program-logs.ts
@@ -1,0 +1,94 @@
+"use client";
+
+import type { Address } from "gill";
+import { useCallback, useEffect, useRef, useState } from "react";
+import { useSolanaClient } from "./client.js";
+
+type LogFilter = "all" | "error" | "success";
+type Commitment = "processed" | "confirmed" | "finalized";
+
+export type ProgramLog = {
+  signature: string;
+  err: unknown | null;
+  logs: string[];
+  slot: number;
+};
+
+export function useWatchProgramLogs(
+  programId: Address | string | undefined,
+  opts: { filter?: LogFilter; commitment?: Commitment; maxItems?: number } = {},
+) {
+  const { filter = "all", commitment = "confirmed", maxItems = 1000 } = opts;
+  const { rpcSubscriptions } = useSolanaClient();
+
+  const [logs, setLogs] = useState<ProgramLog[]>([]);
+  const [error, setError] = useState<Error | null>(null);
+  const [isConnected, setIsConnected] = useState(false);
+  const unsubscribeRef = useRef<null | (() => void)>(null);
+
+  const clear = useCallback(() => {
+    setLogs([]);
+    setError(null);
+  }, []);
+
+  useEffect(() => {
+    if (!programId) return;
+
+    // Cleanup any prior subscription before creating a new one
+    if (unsubscribeRef.current) {
+      try {
+        unsubscribeRef.current();
+      } catch {
+        // ignore
+      }
+      unsubscribeRef.current = null;
+    }
+
+    setIsConnected(false);
+
+    try {
+      // Use Solana logs subscription with a program mention filter
+      // @solana/kit provides logsSubscribe.
+      const sub = (rpcSubscriptions as any).logsSubscribe(
+        { filter: { mentions: [programId] }, commitment },
+        (notification: { value: ProgramLog }) => {
+          const v = notification?.value;
+          if (!v) return;
+          if (filter === "all" || (filter === "success" && !v.err) || (filter === "error" && !!v.err)) {
+            setLogs((prev) => {
+              const next = prev.length >= maxItems ? prev.slice(-maxItems + 1) : prev;
+              return [...next, v];
+            });
+          }
+        },
+        (e: unknown) => setError(e instanceof Error ? e : new Error(String(e))),
+      );
+
+      unsubscribeRef.current = () => {
+        try {
+          sub?.unsubscribe?.();
+        } catch {
+          // ignore
+        }
+      };
+      setIsConnected(true);
+    } catch (e) {
+      setError(e instanceof Error ? e : new Error("Failed to subscribe to program logs"));
+      setIsConnected(false);
+    }
+
+    return () => {
+      if (unsubscribeRef.current) {
+        try {
+          unsubscribeRef.current();
+        } catch {
+          // ignore
+        }
+        unsubscribeRef.current = null;
+      }
+      setIsConnected(false);
+    };
+  }, [programId, commitment, filter, maxItems, rpcSubscriptions]);
+
+  return { logs, error, clear, isConnected } as const;
+}


### PR DESCRIPTION
### Problem

The Gill React library lacked a convenient way for developers to monitor program logs in real-time. Developers needed to manually set up RPC subscriptions and manage the complex lifecycle of WebSocket connections to watch for program-specific logs, which required significant boilerplate code and error handling.

### Summary of Changes

Added ```useWatchProgramLogs``` React hook in ```packages/react/src/hooks/program-logs.ts```

- Provides real-time monitoring of Solana program logs using RPC subscriptions
- Supports filtering by log type (all, error, success)
- Configurable commitment level and maximum log items
- Automatic cleanup and error handling
- Returns logs array, error state, connection status, and clear function

Key Features:
 - Uses ```logsSubscribe``` with program mention filter for efficient log monitoring
 - Implements proper subscription lifecycle management with cleanup
 - Provides TypeScript types for ProgramLog with signature, error, logs, and slot
 - Handles subscription errors gracefully with user-friendly error messages
 - Maintains a rolling buffer of logs with configurable maximum items
 - Integrates seamlessly with existing ```useSolanaClient``` hook

## Fixes #

Issue #280 